### PR TITLE
Refine connection error handling and state management in `MultiDevice…

### DIFF
--- a/app/src/main/kotlin/dev/sebastiano/camerasync/data/repository/KableCameraRepository.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/data/repository/KableCameraRepository.kt
@@ -260,7 +260,7 @@ class KableCameraRepository(
                     "and the camera is in pairing/discoverable mode."
             }
         Log.error(tag = TAG, throwable = lastException) { errorMessage }
-        throw IllegalStateException(errorMessage, lastException)
+        if (lastException is TimeoutCancellationException) throw lastException else throw IllegalStateException(errorMessage, lastException)
     }
 
     private fun isDeviceBonded(macAddress: String): Boolean {

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/data/repository/KableCameraRepository.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/data/repository/KableCameraRepository.kt
@@ -260,7 +260,8 @@ class KableCameraRepository(
                     "and the camera is in pairing/discoverable mode."
             }
         Log.error(tag = TAG, throwable = lastException) { errorMessage }
-        if (lastException is TimeoutCancellationException) throw lastException else throw IllegalStateException(errorMessage, lastException)
+        if (lastException is TimeoutCancellationException) throw lastException
+        else throw IllegalStateException(errorMessage, lastException)
     }
 
     private fun isDeviceBonded(macAddress: String): Boolean {

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/devicesync/DeviceConnectionManager.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/devicesync/DeviceConnectionManager.kt
@@ -4,8 +4,6 @@ import dev.sebastiano.camerasync.domain.repository.CameraConnection
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.Job
 
-private const val TAG = "DeviceConnectionManager"
-
 /**
  * Manages active camera connections and their associated coroutine jobs.
  *

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/devicesync/MultiDeviceSyncCoordinator.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/devicesync/MultiDeviceSyncCoordinator.kt
@@ -414,6 +414,7 @@ constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private suspend fun performInitialSetup(
         connection: CameraConnection,
         device: PairedDevice,
@@ -426,6 +427,8 @@ constructor(
             try {
                 val deviceName = connection.camera.vendor.getPairedDeviceName(deviceNameProvider)
                 connection.setPairedDeviceName(deviceName)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.warn(tag = TAG, throwable = e) {
                     "Failed to set device name for ${device.macAddress}"
@@ -436,6 +439,8 @@ constructor(
         if (capabilities.supportsDateTimeSync) {
             try {
                 connection.syncDateTime(ZonedDateTime.now())
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.warn(tag = TAG, throwable = e) {
                     "Failed to sync date time for ${device.macAddress}"
@@ -446,6 +451,8 @@ constructor(
         if (capabilities.supportsGeoTagging) {
             try {
                 connection.setGeoTaggingEnabled(true)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.warn(tag = TAG, throwable = e) {
                     "Failed to enable geo tagging for ${device.macAddress}"
@@ -458,6 +465,8 @@ constructor(
             try {
                 firmwareVersion = connection.readFirmwareVersion()
                 pairedDevicesRepository.updateFirmwareVersion(device.macAddress, firmwareVersion)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.warn(tag = TAG, throwable = e) {
                     "Failed to read firmware version for ${device.macAddress}"

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/devicesync/MultiDeviceSyncCoordinatorTest.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/devicesync/MultiDeviceSyncCoordinatorTest.kt
@@ -48,6 +48,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@Suppress("LargeClass")
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalUuidApi::class)
 class MultiDeviceSyncCoordinatorTest {
 
@@ -453,18 +454,22 @@ class MultiDeviceSyncCoordinatorTest {
     @Test
     fun `connection timeout from repository updates state to Unreachable`() =
         testScope.runTest {
-            cameraRepository.connectException = try {
-                withTimeout(0) { delay(1) }
-                null
-            } catch (e: TimeoutCancellationException) {
-                e
-            }
+            cameraRepository.connectException =
+                try {
+                    withTimeout(0) { delay(1) }
+                    null
+                } catch (e: TimeoutCancellationException) {
+                    e
+                }
 
             coordinator.startDeviceSync(testDevice1)
             advanceUntilIdle()
 
             val state = coordinator.getDeviceState(testDevice1.macAddress)
-            assertTrue("Expected Unreachable but was $state", state is DeviceConnectionState.Unreachable)
+            assertTrue(
+                "Expected Unreachable but was $state",
+                state is DeviceConnectionState.Unreachable,
+            )
         }
 
     @Test
@@ -477,7 +482,9 @@ class MultiDeviceSyncCoordinatorTest {
 
             val state = coordinator.getDeviceState(testDevice1.macAddress)
             assertTrue(state is DeviceConnectionState.Error)
-            assertTrue((state as DeviceConnectionState.Error).message.contains("Something went wrong"))
+            assertTrue(
+                (state as DeviceConnectionState.Error).message.contains("Something went wrong")
+            )
         }
 
     @Test

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/devicesync/MultiDeviceSyncCoordinatorTest.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/devicesync/MultiDeviceSyncCoordinatorTest.kt
@@ -29,6 +29,8 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import kotlin.uuid.ExperimentalUuidApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -38,6 +40,7 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -448,16 +451,33 @@ class MultiDeviceSyncCoordinatorTest {
     }
 
     @Test
+    fun `connection timeout from repository updates state to Unreachable`() =
+        testScope.runTest {
+            cameraRepository.connectException = try {
+                withTimeout(0) { delay(1) }
+                null
+            } catch (e: TimeoutCancellationException) {
+                e
+            }
+
+            coordinator.startDeviceSync(testDevice1)
+            advanceUntilIdle()
+
+            val state = coordinator.getDeviceState(testDevice1.macAddress)
+            assertTrue("Expected Unreachable but was $state", state is DeviceConnectionState.Unreachable)
+        }
+
+    @Test
     fun `connection error updates state to Error`() =
         testScope.runTest {
-            cameraRepository.connectException = IllegalStateException("Connection failed")
+            cameraRepository.connectException = IllegalStateException("Something went wrong")
 
             coordinator.startDeviceSync(testDevice1)
             advanceUntilIdle()
 
             val state = coordinator.getDeviceState(testDevice1.macAddress)
             assertTrue(state is DeviceConnectionState.Error)
-            assertTrue((state as DeviceConnectionState.Error).message.contains("Connection failed"))
+            assertTrue((state as DeviceConnectionState.Error).message.contains("Something went wrong"))
         }
 
     @Test


### PR DESCRIPTION
…SyncCoordinator`

- Updated `KableCameraRepository` to rethrow `TimeoutCancellationException` instead of wrapping it in an `IllegalStateException`, allowing for more granular error handling.
- Enhanced `MultiDeviceSyncCoordinatorTest` with a new test case to verify that connection timeouts correctly transition the device state to `Unreachable`.
- Updated existing connection error tests to reflect changes in exception messaging and ensure accurate state reporting.

These changes improve the application's ability to differentiate between transient connection timeouts and other fatal errors, leading to more accurate device status reporting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change in coroutine exception propagation around BLE connection/setup; risk is limited to how timeouts/cancellations map to device states.
> 
> **Overview**
> Improves connection error classification by **preserving coroutine timeouts**: `KableCameraRepository.connect()` now rethrows `TimeoutCancellationException` instead of wrapping it in `IllegalStateException`, enabling callers to treat timeouts distinctly.
> 
> `MultiDeviceSyncCoordinator`’s initial setup steps now explicitly rethrow `CancellationException` (instead of logging it as a generic failure), ensuring cancellations/timeout propagation correctly aborts work. Tests were updated with a new case asserting repository-level timeouts transition devices to `DeviceConnectionState.Unreachable`, and existing error-message assertions were adjusted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4172f62b9ad20888137019a5222d9ad401cdeb38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->