### PR TITLE
More cleanup

### DIFF
--- a/app/src/main/kotlin/dev/sebastiano/camerasync/data/repository/KableCameraRepository.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/data/repository/KableCameraRepository.kt
@@ -260,8 +260,7 @@ class KableCameraRepository(
                     "and the camera is in pairing/discoverable mode."
             }
         Log.error(tag = TAG, throwable = lastException) { errorMessage }
-        if (lastException is TimeoutCancellationException) throw lastException
-        else throw IllegalStateException(errorMessage, lastException)
+        if (lastException is TimeoutCancellationException) throw lastException else throw IllegalStateException(errorMessage, lastException)
     }
 
     private fun isDeviceBonded(macAddress: String): Boolean {

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/data/repository/KableCameraRepository.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/data/repository/KableCameraRepository.kt
@@ -260,7 +260,8 @@ class KableCameraRepository(
                     "and the camera is in pairing/discoverable mode."
             }
         Log.error(tag = TAG, throwable = lastException) { errorMessage }
-        if (lastException is TimeoutCancellationException) throw lastException else throw IllegalStateException(errorMessage, lastException)
+        if (lastException is TimeoutCancellationException) throw lastException
+        else throw IllegalStateException(errorMessage, lastException)
     }
 
     private fun isDeviceBonded(macAddress: String): Boolean {

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/data/repository/KableCameraRepository.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/data/repository/KableCameraRepository.kt
@@ -178,10 +178,6 @@ class KableCameraRepository(
                 "Device ${camera.macAddress} is bonded. " +
                     "Cameras may need 10-15 seconds to start advertising after being turned on."
             }
-            // Give bonded cameras time to start advertising after power-on
-            // This is especially important when cameras are turned on while the app is running
-            // We already have a delay in setDevicePresence, but add extra time here too
-            delay(5_000L)
         }
 
         // Retry logic for bonded devices that might be slow to advertise

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/devicesync/MultiDeviceSyncCoordinatorTest.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/devicesync/MultiDeviceSyncCoordinatorTest.kt
@@ -473,27 +473,6 @@ class MultiDeviceSyncCoordinatorTest {
         }
 
     @Test
-    fun `connection timeout from repository updates state to Unreachable`() =
-        testScope.runTest {
-            cameraRepository.connectException =
-                try {
-                    withTimeout(0) { delay(1) }
-                    null
-                } catch (e: TimeoutCancellationException) {
-                    e
-                }
-
-            coordinator.startDeviceSync(testDevice1)
-            advanceUntilIdle()
-
-            val state = coordinator.getDeviceState(testDevice1.macAddress)
-            assertTrue(
-                "Expected Unreachable but was $state",
-                state is DeviceConnectionState.Unreachable,
-            )
-        }
-
-    @Test
     fun `connection error updates state to Error`() =
         testScope.runTest {
             cameraRepository.connectException = IllegalStateException("Something went wrong")

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/devicesync/MultiDeviceSyncCoordinatorTest.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/devicesync/MultiDeviceSyncCoordinatorTest.kt
@@ -475,18 +475,22 @@ class MultiDeviceSyncCoordinatorTest {
     @Test
     fun `connection timeout from repository updates state to Unreachable`() =
         testScope.runTest {
-            cameraRepository.connectException = try {
-                withTimeout(0) { delay(1) }
-                null
-            } catch (e: TimeoutCancellationException) {
-                e
-            }
+            cameraRepository.connectException =
+                try {
+                    withTimeout(0) { delay(1) }
+                    null
+                } catch (e: TimeoutCancellationException) {
+                    e
+                }
 
             coordinator.startDeviceSync(testDevice1)
             advanceUntilIdle()
 
             val state = coordinator.getDeviceState(testDevice1.macAddress)
-            assertTrue("Expected Unreachable but was $state", state is DeviceConnectionState.Unreachable)
+            assertTrue(
+                "Expected Unreachable but was $state",
+                state is DeviceConnectionState.Unreachable,
+            )
         }
 
     @Test

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/devicesync/MultiDeviceSyncCoordinatorTest.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/devicesync/MultiDeviceSyncCoordinatorTest.kt
@@ -473,6 +473,23 @@ class MultiDeviceSyncCoordinatorTest {
         }
 
     @Test
+    fun `connection timeout from repository updates state to Unreachable`() =
+        testScope.runTest {
+            cameraRepository.connectException = try {
+                withTimeout(0) { delay(1) }
+                null
+            } catch (e: TimeoutCancellationException) {
+                e
+            }
+
+            coordinator.startDeviceSync(testDevice1)
+            advanceUntilIdle()
+
+            val state = coordinator.getDeviceState(testDevice1.macAddress)
+            assertTrue("Expected Unreachable but was $state", state is DeviceConnectionState.Unreachable)
+        }
+
+    @Test
     fun `connection error updates state to Error`() =
         testScope.runTest {
             cameraRepository.connectException = IllegalStateException("Something went wrong")

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/domain/vendor/CameraVendorRegistryTest.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/domain/vendor/CameraVendorRegistryTest.kt
@@ -1,0 +1,288 @@
+package dev.sebastiano.camerasync.domain.vendor
+
+import dev.sebastiano.camerasync.vendors.ricoh.RicohCameraVendor
+import dev.sebastiano.camerasync.vendors.ricoh.RicohGattSpec
+import dev.sebastiano.camerasync.vendors.sony.SonyCameraVendor
+import dev.sebastiano.camerasync.vendors.sony.SonyGattSpec
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalUuidApi::class)
+class CameraVendorRegistryTest {
+
+    private lateinit var registry: CameraVendorRegistry
+
+    @Before
+    fun setup() {
+        registry =
+            DefaultCameraVendorRegistry(vendors = listOf(RicohCameraVendor, SonyCameraVendor))
+    }
+
+    // getAllVendors tests
+
+    @Test
+    fun `getAllVendors returns all registered vendors`() {
+        val vendors = registry.getAllVendors()
+        assertEquals(2, vendors.size)
+        assertTrue(vendors.contains(RicohCameraVendor))
+        assertTrue(vendors.contains(SonyCameraVendor))
+    }
+
+    @Test
+    fun `getAllVendors returns vendors in registration order`() {
+        val vendors = registry.getAllVendors()
+        assertEquals(RicohCameraVendor, vendors[0])
+        assertEquals(SonyCameraVendor, vendors[1])
+    }
+
+    // identifyVendor tests
+
+    @Test
+    fun `identifyVendor returns Ricoh for Ricoh service UUID`() {
+        val vendor =
+            registry.identifyVendor(
+                deviceName = null,
+                serviceUuids = listOf(RicohGattSpec.SCAN_FILTER_SERVICE_UUID),
+                manufacturerData = emptyMap(),
+            )
+        assertEquals(RicohCameraVendor, vendor)
+    }
+
+    @Test
+    fun `identifyVendor returns Ricoh for GR device name`() {
+        val vendor =
+            registry.identifyVendor(
+                deviceName = "GR IIIx",
+                serviceUuids = emptyList(),
+                manufacturerData = emptyMap(),
+            )
+        assertEquals(RicohCameraVendor, vendor)
+    }
+
+    @Test
+    fun `identifyVendor returns Sony for Sony service UUID`() {
+        val vendor =
+            registry.identifyVendor(
+                deviceName = null,
+                serviceUuids = listOf(SonyGattSpec.REMOTE_CONTROL_SERVICE_UUID),
+                manufacturerData = emptyMap(),
+            )
+        assertEquals(SonyCameraVendor, vendor)
+    }
+
+    @Test
+    fun `identifyVendor returns Sony for ILCE device name`() {
+        val vendor =
+            registry.identifyVendor(
+                deviceName = "ILCE-7M4",
+                serviceUuids = emptyList(),
+                manufacturerData = emptyMap(),
+            )
+        assertEquals(SonyCameraVendor, vendor)
+    }
+
+    @Test
+    fun `identifyVendor returns Sony for Sony manufacturer data`() {
+        val sonyMfrData = mapOf(SonyCameraVendor.SONY_MANUFACTURER_ID to byteArrayOf(0x03, 0x00))
+        val vendor =
+            registry.identifyVendor(
+                deviceName = null,
+                serviceUuids = emptyList(),
+                manufacturerData = sonyMfrData,
+            )
+        assertEquals(SonyCameraVendor, vendor)
+    }
+
+    @Test
+    fun `identifyVendor returns null for unrecognized device`() {
+        val vendor =
+            registry.identifyVendor(
+                deviceName = "Unknown Device",
+                serviceUuids = listOf(Uuid.parse("00001800-0000-1000-8000-00805f9b34fb")),
+                manufacturerData = emptyMap(),
+            )
+        assertNull(vendor)
+    }
+
+    @Test
+    fun `identifyVendor returns null for device with no identifying information`() {
+        val vendor =
+            registry.identifyVendor(
+                deviceName = null,
+                serviceUuids = emptyList(),
+                manufacturerData = emptyMap(),
+            )
+        assertNull(vendor)
+    }
+
+    @Test
+    fun `identifyVendor returns first matching vendor when multiple vendors match`() {
+        // Create a registry with a custom order
+        val customRegistry =
+            DefaultCameraVendorRegistry(vendors = listOf(SonyCameraVendor, RicohCameraVendor))
+
+        // Use a device name that could match both (hypothetically)
+        // In reality, this shouldn't happen, but the registry should return the first match
+        val vendor =
+            customRegistry.identifyVendor(
+                deviceName = "GR IIIx",
+                serviceUuids = emptyList(),
+                manufacturerData = emptyMap(),
+            )
+
+        // Should return Ricoh since it actually recognizes "GR IIIx"
+        assertEquals(RicohCameraVendor, vendor)
+    }
+
+    // getVendorById tests
+
+    @Test
+    fun `getVendorById returns Ricoh vendor by id`() {
+        val vendor = registry.getVendorById("ricoh")
+        assertEquals(RicohCameraVendor, vendor)
+    }
+
+    @Test
+    fun `getVendorById returns Sony vendor by id`() {
+        val vendor = registry.getVendorById("sony")
+        assertEquals(SonyCameraVendor, vendor)
+    }
+
+    @Test
+    fun `getVendorById returns null for unknown vendor id`() {
+        val vendor = registry.getVendorById("unknown")
+        assertNull(vendor)
+    }
+
+    @Test
+    fun `getVendorById is case sensitive`() {
+        val vendor = registry.getVendorById("RICOH")
+        assertNull(vendor)
+    }
+
+    // getAllScanFilterUuids tests
+
+    @Test
+    fun `getAllScanFilterUuids returns UUIDs from all vendors`() {
+        val uuids = registry.getAllScanFilterUuids()
+
+        // Should contain Ricoh UUIDs
+        assertTrue(uuids.contains(RicohGattSpec.SCAN_FILTER_SERVICE_UUID))
+
+        // Should contain Sony UUIDs
+        assertTrue(uuids.contains(SonyGattSpec.REMOTE_CONTROL_SERVICE_UUID))
+        assertTrue(uuids.contains(SonyGattSpec.PAIRING_SERVICE_UUID))
+    }
+
+    @Test
+    fun `getAllScanFilterUuids returns distinct UUIDs`() {
+        val uuids = registry.getAllScanFilterUuids()
+        val distinctUuids = uuids.distinct()
+        assertEquals(distinctUuids.size, uuids.size)
+    }
+
+    @Test
+    fun `getAllScanFilterUuids handles vendors with multiple UUIDs`() {
+        val uuids = registry.getAllScanFilterUuids()
+
+        // Sony has 2 scan filter UUIDs
+        val sonyUuids =
+            uuids.filter {
+                it == SonyGattSpec.REMOTE_CONTROL_SERVICE_UUID ||
+                    it == SonyGattSpec.PAIRING_SERVICE_UUID
+            }
+        assertEquals(2, sonyUuids.size)
+    }
+
+    // getAllScanFilterDeviceNames tests
+
+    @Test
+    fun `getAllScanFilterDeviceNames returns device name prefixes from all vendors`() {
+        val names = registry.getAllScanFilterDeviceNames()
+
+        // Should contain Ricoh device names
+        assertTrue(names.contains("GR"))
+        assertTrue(names.contains("RICOH"))
+
+        // Should contain Sony device names
+        assertTrue(names.contains("ILCE-"))
+    }
+
+    @Test
+    fun `getAllScanFilterDeviceNames returns distinct names`() {
+        val names = registry.getAllScanFilterDeviceNames()
+        val distinctNames = names.distinct()
+        assertEquals(distinctNames.size, names.size)
+    }
+
+    @Test
+    fun `getAllScanFilterDeviceNames handles vendors with multiple name prefixes`() {
+        val names = registry.getAllScanFilterDeviceNames()
+
+        // Ricoh has 2 device name prefixes
+        val ricohNames = names.filter { it == "GR" || it == "RICOH" }
+        assertEquals(2, ricohNames.size)
+    }
+
+    // Empty registry tests
+
+    @Test
+    fun `empty registry returns empty vendor list`() {
+        val emptyRegistry = DefaultCameraVendorRegistry(vendors = emptyList())
+        assertEquals(0, emptyRegistry.getAllVendors().size)
+    }
+
+    @Test
+    fun `empty registry returns null for any device identification`() {
+        val emptyRegistry = DefaultCameraVendorRegistry(vendors = emptyList())
+        val vendor =
+            emptyRegistry.identifyVendor(
+                deviceName = "GR IIIx",
+                serviceUuids = listOf(RicohGattSpec.SCAN_FILTER_SERVICE_UUID),
+                manufacturerData = emptyMap(),
+            )
+        assertNull(vendor)
+    }
+
+    @Test
+    fun `empty registry returns null for vendor lookup by id`() {
+        val emptyRegistry = DefaultCameraVendorRegistry(vendors = emptyList())
+        assertNull(emptyRegistry.getVendorById("ricoh"))
+    }
+
+    @Test
+    fun `empty registry returns empty scan filter UUID list`() {
+        val emptyRegistry = DefaultCameraVendorRegistry(vendors = emptyList())
+        assertEquals(0, emptyRegistry.getAllScanFilterUuids().size)
+    }
+
+    @Test
+    fun `empty registry returns empty device name list`() {
+        val emptyRegistry = DefaultCameraVendorRegistry(vendors = emptyList())
+        assertEquals(0, emptyRegistry.getAllScanFilterDeviceNames().size)
+    }
+
+    // Single vendor registry tests
+
+    @Test
+    fun `single vendor registry works correctly`() {
+        val singleVendorRegistry = DefaultCameraVendorRegistry(vendors = listOf(RicohCameraVendor))
+
+        assertEquals(1, singleVendorRegistry.getAllVendors().size)
+        assertEquals(RicohCameraVendor, singleVendorRegistry.getVendorById("ricoh"))
+        assertNull(singleVendorRegistry.getVendorById("sony"))
+
+        val vendor =
+            singleVendorRegistry.identifyVendor(
+                deviceName = "GR IIIx",
+                serviceUuids = emptyList(),
+                manufacturerData = emptyMap(),
+            )
+        assertEquals(RicohCameraVendor, vendor)
+    }
+}

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/vendors/ricoh/RicohCameraVendorTest.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/vendors/ricoh/RicohCameraVendorTest.kt
@@ -1,0 +1,176 @@
+package dev.sebastiano.camerasync.vendors.ricoh
+
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalUuidApi::class)
+class RicohCameraVendorTest {
+
+    @Test
+    fun `vendorId is ricoh`() {
+        assertEquals("ricoh", RicohCameraVendor.vendorId)
+    }
+
+    @Test
+    fun `vendorName is Ricoh`() {
+        assertEquals("Ricoh", RicohCameraVendor.vendorName)
+    }
+
+    @Test
+    fun `recognizes device with Ricoh service UUID`() {
+        val serviceUuids = listOf(RicohGattSpec.SCAN_FILTER_SERVICE_UUID)
+        assertTrue(RicohCameraVendor.recognizesDevice("GR IIIx", serviceUuids, emptyMap()))
+    }
+
+    @Test
+    fun `recognizes device with Ricoh service UUID regardless of device name`() {
+        val serviceUuids = listOf(RicohGattSpec.SCAN_FILTER_SERVICE_UUID)
+        assertTrue(RicohCameraVendor.recognizesDevice(null, serviceUuids, emptyMap()))
+        assertTrue(RicohCameraVendor.recognizesDevice("", serviceUuids, emptyMap()))
+        assertTrue(RicohCameraVendor.recognizesDevice("Unknown Camera", serviceUuids, emptyMap()))
+    }
+
+    @Test
+    fun `recognizes device by GR name prefix even without service UUID`() {
+        assertTrue(RicohCameraVendor.recognizesDevice("GR IIIx", emptyList(), emptyMap()))
+        assertTrue(RicohCameraVendor.recognizesDevice("GR III", emptyList(), emptyMap()))
+        assertTrue(RicohCameraVendor.recognizesDevice("GR II", emptyList(), emptyMap()))
+        assertTrue(
+            RicohCameraVendor.recognizesDevice("gr iiix", emptyList(), emptyMap())
+        ) // case-insensitive
+    }
+
+    @Test
+    fun `recognizes device by RICOH name prefix even without service UUID`() {
+        assertTrue(RicohCameraVendor.recognizesDevice("RICOH GR IIIx", emptyList(), emptyMap()))
+        assertTrue(RicohCameraVendor.recognizesDevice("RICOH Camera", emptyList(), emptyMap()))
+        assertTrue(
+            RicohCameraVendor.recognizesDevice("ricoh test", emptyList(), emptyMap())
+        ) // case-insensitive
+    }
+
+    @Test
+    fun `does not recognize device without service UUID or recognized name`() {
+        assertFalse(RicohCameraVendor.recognizesDevice("Unknown Camera", emptyList(), emptyMap()))
+        assertFalse(RicohCameraVendor.recognizesDevice("Sony Camera", emptyList(), emptyMap()))
+        assertFalse(RicohCameraVendor.recognizesDevice(null, emptyList(), emptyMap()))
+    }
+
+    @Test
+    fun `recognizes device with non-Ricoh service UUID and Ricoh name`() {
+        val otherServiceUuids = listOf(Uuid.parse("00001800-0000-1000-8000-00805f9b34fb"))
+        assertTrue(RicohCameraVendor.recognizesDevice("GR IIIx", otherServiceUuids, emptyMap()))
+    }
+
+    @Test
+    fun `capabilities indicate firmware version support`() {
+        assertTrue(RicohCameraVendor.getCapabilities().supportsFirmwareVersion)
+    }
+
+    @Test
+    fun `capabilities indicate device name support`() {
+        assertTrue(RicohCameraVendor.getCapabilities().supportsDeviceName)
+    }
+
+    @Test
+    fun `capabilities indicate date time sync support`() {
+        assertTrue(RicohCameraVendor.getCapabilities().supportsDateTimeSync)
+    }
+
+    @Test
+    fun `capabilities indicate geo tagging support`() {
+        assertTrue(RicohCameraVendor.getCapabilities().supportsGeoTagging)
+    }
+
+    @Test
+    fun `capabilities indicate location sync support`() {
+        assertTrue(RicohCameraVendor.getCapabilities().supportsLocationSync)
+    }
+
+    @Test
+    fun `capabilities indicate hardware revision support`() {
+        assertTrue(RicohCameraVendor.getCapabilities().supportsHardwareRevision)
+    }
+
+    @Test
+    fun `gattSpec is RicohGattSpec`() {
+        assertEquals(RicohGattSpec, RicohCameraVendor.gattSpec)
+    }
+
+    @Test
+    fun `protocol is RicohProtocol`() {
+        assertEquals(RicohProtocol, RicohCameraVendor.protocol)
+    }
+
+    // Model extraction tests
+
+    @Test
+    fun `extractModelFromPairingName extracts GR IIIx`() {
+        assertEquals("GR IIIx", RicohCameraVendor.extractModelFromPairingName("GR IIIx"))
+        assertEquals(
+            "GR IIIx",
+            RicohCameraVendor.extractModelFromPairingName("gr iiix"),
+        ) // case-insensitive
+        assertEquals(
+            "GR IIIx",
+            RicohCameraVendor.extractModelFromPairingName("RICOH GR IIIx Camera"),
+        )
+        assertEquals(
+            "GR IIIx",
+            RicohCameraVendor.extractModelFromPairingName("  GR IIIx  "),
+        ) // with whitespace
+    }
+
+    @Test
+    fun `extractModelFromPairingName extracts GR III but not GR IIIx`() {
+        assertEquals("GR III", RicohCameraVendor.extractModelFromPairingName("GR III"))
+        assertEquals(
+            "GR III",
+            RicohCameraVendor.extractModelFromPairingName("gr iii"),
+        ) // case-insensitive
+        assertEquals("GR III", RicohCameraVendor.extractModelFromPairingName("RICOH GR III"))
+    }
+
+    @Test
+    fun `extractModelFromPairingName extracts other GR models`() {
+        assertEquals("GR 2", RicohCameraVendor.extractModelFromPairingName("GR 2"))
+        assertEquals("GR 1", RicohCameraVendor.extractModelFromPairingName("GR 1"))
+        assertEquals("GR 10", RicohCameraVendor.extractModelFromPairingName("GR 10"))
+        assertEquals("GR 3x", RicohCameraVendor.extractModelFromPairingName("GR 3x"))
+    }
+
+    @Test
+    fun `extractModelFromPairingName returns pairing name for GR or RICOH prefix`() {
+        assertEquals(
+            "GR Custom Model",
+            RicohCameraVendor.extractModelFromPairingName("GR Custom Model"),
+        )
+        assertEquals("RICOH Test", RicohCameraVendor.extractModelFromPairingName("RICOH Test"))
+    }
+
+    @Test
+    fun `extractModelFromPairingName returns name as-is for non-Ricoh names`() {
+        assertEquals("Sony Camera", RicohCameraVendor.extractModelFromPairingName("Sony Camera"))
+        assertEquals(
+            "Unknown Device",
+            RicohCameraVendor.extractModelFromPairingName("Unknown Device"),
+        )
+    }
+
+    @Test
+    fun `extractModelFromPairingName returns Unknown for null`() {
+        assertEquals("Unknown", RicohCameraVendor.extractModelFromPairingName(null))
+    }
+
+    @Test
+    fun `extractModelFromPairingName returns empty string for empty input`() {
+        // The implementation returns the trimmed name as-is when it doesn't match any pattern
+        // For empty strings, this results in an empty string being returned
+        assertEquals("", RicohCameraVendor.extractModelFromPairingName(""))
+        assertEquals("", RicohCameraVendor.extractModelFromPairingName("   "))
+    }
+}

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/vendors/ricoh/RicohGattSpecTest.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/vendors/ricoh/RicohGattSpecTest.kt
@@ -1,0 +1,200 @@
+package dev.sebastiano.camerasync.vendors.ricoh
+
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalUuidApi::class)
+class RicohGattSpecTest {
+
+    @Test
+    fun `scan filter service UUID matches specification`() {
+        assertEquals(
+            Uuid.parse("84A0DD62-E8AA-4D0F-91DB-819B6724C69E"),
+            RicohGattSpec.SCAN_FILTER_SERVICE_UUID,
+        )
+    }
+
+    @Test
+    fun `scan filter service UUIDs list contains scan filter UUID`() {
+        assertEquals(1, RicohGattSpec.scanFilterServiceUuids.size)
+        assertEquals(
+            RicohGattSpec.SCAN_FILTER_SERVICE_UUID,
+            RicohGattSpec.scanFilterServiceUuids[0],
+        )
+    }
+
+    @Test
+    fun `scan filter device names includes GR and RICOH`() {
+        assertEquals(2, RicohGattSpec.scanFilterDeviceNames.size)
+        assertEquals(listOf("GR", "RICOH"), RicohGattSpec.scanFilterDeviceNames)
+    }
+
+    @Test
+    fun `firmware service UUID matches specification`() {
+        assertEquals(
+            Uuid.parse("9a5ed1c5-74cc-4c50-b5b6-66a48e7ccff1"),
+            RicohGattSpec.Firmware.SERVICE_UUID,
+        )
+    }
+
+    @Test
+    fun `firmware version characteristic UUID matches specification`() {
+        assertEquals(
+            Uuid.parse("b4eb8905-7411-40a6-a367-2834c2157ea7"),
+            RicohGattSpec.Firmware.VERSION_CHARACTERISTIC_UUID,
+        )
+    }
+
+    @Test
+    fun `firmware service exposed via interface property`() {
+        assertEquals(RicohGattSpec.Firmware.SERVICE_UUID, RicohGattSpec.firmwareServiceUuid)
+    }
+
+    @Test
+    fun `firmware version characteristic exposed via interface property`() {
+        assertEquals(
+            RicohGattSpec.Firmware.VERSION_CHARACTERISTIC_UUID,
+            RicohGattSpec.firmwareVersionCharacteristicUuid,
+        )
+    }
+
+    @Test
+    fun `device name service UUID matches specification`() {
+        assertEquals(
+            Uuid.parse("0f291746-0c80-4726-87a7-3c501fd3b4b6"),
+            RicohGattSpec.DeviceName.SERVICE_UUID,
+        )
+    }
+
+    @Test
+    fun `device name characteristic UUID matches specification`() {
+        assertEquals(
+            Uuid.parse("fe3a32f8-a189-42de-a391-bc81ae4daa76"),
+            RicohGattSpec.DeviceName.NAME_CHARACTERISTIC_UUID,
+        )
+    }
+
+    @Test
+    fun `device name service exposed via interface property`() {
+        assertEquals(RicohGattSpec.DeviceName.SERVICE_UUID, RicohGattSpec.deviceNameServiceUuid)
+    }
+
+    @Test
+    fun `device name characteristic exposed via interface property`() {
+        assertEquals(
+            RicohGattSpec.DeviceName.NAME_CHARACTERISTIC_UUID,
+            RicohGattSpec.deviceNameCharacteristicUuid,
+        )
+    }
+
+    @Test
+    fun `dateTime service UUID matches specification`() {
+        assertEquals(
+            Uuid.parse("4b445988-caa0-4dd3-941d-37b4f52aca86"),
+            RicohGattSpec.DateTime.SERVICE_UUID,
+        )
+    }
+
+    @Test
+    fun `dateTime characteristic UUID matches specification`() {
+        assertEquals(
+            Uuid.parse("fa46bbdd-8a8f-4796-8cf3-aa58949b130a"),
+            RicohGattSpec.DateTime.DATE_TIME_CHARACTERISTIC_UUID,
+        )
+    }
+
+    @Test
+    fun `geoTagging characteristic UUID matches specification`() {
+        assertEquals(
+            Uuid.parse("a36afdcf-6b67-4046-9be7-28fb67dbc071"),
+            RicohGattSpec.DateTime.GEO_TAGGING_CHARACTERISTIC_UUID,
+        )
+    }
+
+    @Test
+    fun `dateTime service exposed via interface property`() {
+        assertEquals(RicohGattSpec.DateTime.SERVICE_UUID, RicohGattSpec.dateTimeServiceUuid)
+    }
+
+    @Test
+    fun `dateTime characteristic exposed via interface property`() {
+        assertEquals(
+            RicohGattSpec.DateTime.DATE_TIME_CHARACTERISTIC_UUID,
+            RicohGattSpec.dateTimeCharacteristicUuid,
+        )
+    }
+
+    @Test
+    fun `geoTagging characteristic exposed via interface property`() {
+        assertEquals(
+            RicohGattSpec.DateTime.GEO_TAGGING_CHARACTERISTIC_UUID,
+            RicohGattSpec.geoTaggingCharacteristicUuid,
+        )
+    }
+
+    @Test
+    fun `location service UUID matches specification`() {
+        assertEquals(
+            Uuid.parse("84a0dd62-e8aa-4d0f-91db-819b6724c69e"),
+            RicohGattSpec.Location.SERVICE_UUID,
+        )
+    }
+
+    @Test
+    fun `location characteristic UUID matches specification`() {
+        assertEquals(
+            Uuid.parse("28f59d60-8b8e-4fcd-a81f-61bdb46595a9"),
+            RicohGattSpec.Location.LOCATION_CHARACTERISTIC_UUID,
+        )
+    }
+
+    @Test
+    fun `location service exposed via interface property`() {
+        assertEquals(RicohGattSpec.Location.SERVICE_UUID, RicohGattSpec.locationServiceUuid)
+    }
+
+    @Test
+    fun `location characteristic exposed via interface property`() {
+        assertEquals(
+            RicohGattSpec.Location.LOCATION_CHARACTERISTIC_UUID,
+            RicohGattSpec.locationCharacteristicUuid,
+        )
+    }
+
+    @Test
+    fun `location service UUID matches scan filter service UUID`() {
+        // In Ricoh's implementation, the location service and scan filter use the same UUID
+        assertEquals(RicohGattSpec.SCAN_FILTER_SERVICE_UUID, RicohGattSpec.Location.SERVICE_UUID)
+    }
+
+    @Test
+    fun `all UUIDs are lowercase with uppercase letters`() {
+        // Verify UUID format consistency - UUIDs should use uppercase hex digits
+        val allUuids =
+            listOf(
+                RicohGattSpec.SCAN_FILTER_SERVICE_UUID.toString(),
+                RicohGattSpec.Firmware.SERVICE_UUID.toString(),
+                RicohGattSpec.Firmware.VERSION_CHARACTERISTIC_UUID.toString(),
+                RicohGattSpec.DeviceName.SERVICE_UUID.toString(),
+                RicohGattSpec.DeviceName.NAME_CHARACTERISTIC_UUID.toString(),
+                RicohGattSpec.DateTime.SERVICE_UUID.toString(),
+                RicohGattSpec.DateTime.DATE_TIME_CHARACTERISTIC_UUID.toString(),
+                RicohGattSpec.DateTime.GEO_TAGGING_CHARACTERISTIC_UUID.toString(),
+                RicohGattSpec.Location.SERVICE_UUID.toString(),
+                RicohGattSpec.Location.LOCATION_CHARACTERISTIC_UUID.toString(),
+            )
+
+        // All UUIDs should be properly formatted (8-4-4-4-12 format)
+        allUuids.forEach { uuid ->
+            val parts = uuid.split("-")
+            assertEquals("UUID $uuid should have 5 parts", 5, parts.size)
+            assertEquals("First part should be 8 chars", 8, parts[0].length)
+            assertEquals("Second part should be 4 chars", 4, parts[1].length)
+            assertEquals("Third part should be 4 chars", 4, parts[2].length)
+            assertEquals("Fourth part should be 4 chars", 4, parts[3].length)
+            assertEquals("Fifth part should be 12 chars", 12, parts[4].length)
+        }
+    }
+}


### PR DESCRIPTION
moar

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts BLE connection timing for bonded devices, which can affect real-world connect reliability; the rest is documentation and additive test coverage.
> 
> **Overview**
> Updates `AGENTS.md` to better document the *multi-vendor* strategy/registry architecture, supported vendors, and testing expectations.
> 
> Simplifies `KableCameraRepository.connect` behavior for bonded devices by removing an extra fixed pre-scan delay while keeping the existing retry/timeout approach.
> 
> Adds new unit tests covering `DefaultCameraVendorRegistry` identification/aggregation behavior plus Ricoh vendor recognition/model extraction and Ricoh GATT UUID/spec constants (`CameraVendorRegistryTest`, `RicohCameraVendorTest`, `RicohGattSpecTest`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68b8e33a69ee3139ec8aef432867e385ffdec585. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->