### PR TITLE
Implement Ricoh firmware update checking with hybrid strategy

### DIFF
--- a/.github/workflows/update_firmware_data.yml
+++ b/.github/workflows/update_firmware_data.yml
@@ -1,0 +1,45 @@
+name: Update Firmware Data
+
+on:
+  schedule:
+    # Run daily at 8:00 AM UTC
+    - cron: '0 8 * * *'
+  workflow_dispatch:  # Allow manual triggering
+
+permissions:
+  contents: write
+
+jobs:
+  update-firmware:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install -r scripts/requirements.txt
+
+      - name: Run firmware scraper
+        run: |
+          cd scripts
+          python scrape_ricoh_firmware.py
+          cd ..
+
+      - name: Prepare deployment directory
+        run: |
+          mkdir -p deploy
+          cp scripts/ricoh_firmware.json deploy/
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./deploy
+          destination_dir: firmware
+          keep_files: false

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,7 @@ keystore.properties
 
 # VSC-forks shit
 /.vscode/tasks.json
+
+# Generated firmware data
+scripts/ricoh_firmware.json
+deploy/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.metro)
     alias(libs.plugins.protobuf)
     alias(libs.plugins.ktfmt)
@@ -115,6 +116,7 @@ dependencies {
     implementation(libs.maplibre.core)
     implementation(libs.maplibre.material3)
     implementation(libs.maplibre.spatialk)
+    implementation(libs.kotlinx.serialization.json)
     implementation(libs.protobuf.kotlin.lite)
 
     debugImplementation(libs.androidx.ui.test.manifest)
@@ -123,6 +125,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockk)
+    testImplementation(libs.mockwebserver)
 
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/di/AppGraph.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/di/AppGraph.kt
@@ -27,6 +27,8 @@ import dev.sebastiano.camerasync.domain.vendor.DefaultCameraVendorRegistry
 import dev.sebastiano.camerasync.feedback.AndroidIssueReporter
 import dev.sebastiano.camerasync.feedback.IssueReporter
 import dev.sebastiano.camerasync.firmware.FirmwareUpdateChecker
+import dev.sebastiano.camerasync.firmware.ricoh.RicohFirmwareUpdateChecker
+import dev.sebastiano.camerasync.firmware.sony.SonyFirmwareUpdateChecker
 import dev.sebastiano.camerasync.logging.LogRepository
 import dev.sebastiano.camerasync.logging.LogViewerViewModel
 import dev.sebastiano.camerasync.logging.LogcatLogRepository
@@ -198,7 +200,7 @@ interface AppGraph {
     @Provides
     @SingleIn(AppGraph::class)
     fun provideFirmwareUpdateCheckers(context: Context): List<FirmwareUpdateChecker> =
-        listOf(dev.sebastiano.camerasync.firmware.sony.SonyFirmwareUpdateChecker(context))
+        listOf(SonyFirmwareUpdateChecker(context), RicohFirmwareUpdateChecker(context))
 
     @DependencyGraph.Factory
     interface Factory {

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/firmware/ricoh/RicohFirmwareJson.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/firmware/ricoh/RicohFirmwareJson.kt
@@ -1,0 +1,25 @@
+package dev.sebastiano.camerasync.firmware.ricoh
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** Scraped firmware data from GitHub Pages (see `scripts/scrape_ricoh_firmware.py`). */
+@Serializable
+data class RicohFirmwareData(
+    @SerialName("last_updated") val lastUpdated: String? = null,
+    val cameras: Map<String, String> = emptyMap(),
+)
+
+/** Request body for Ricoh AWS firmware API. */
+@Serializable
+data class RicohFirmwareApiRequest(
+    @SerialName("phone_model") val phoneModel: String,
+    @SerialName("phone_os") val phoneOs: String,
+    @SerialName("phone_os_version") val phoneOsVersion: String,
+    @SerialName("phone_language") val phoneLanguage: String,
+    @SerialName("phone_app_ver") val phoneAppVer: String,
+    val model: String,
+)
+
+/** Response from Ricoh AWS firmware API. */
+@Serializable data class RicohFirmwareApiResponse(val version: String = "")

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/firmware/ricoh/RicohFirmwareUpdateChecker.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/firmware/ricoh/RicohFirmwareUpdateChecker.kt
@@ -1,0 +1,296 @@
+package dev.sebastiano.camerasync.firmware.ricoh
+
+import android.content.Context
+import com.juul.khronicle.Log
+import dev.sebastiano.camerasync.domain.model.PairedDevice
+import dev.sebastiano.camerasync.firmware.FirmwareUpdateCheckResult
+import dev.sebastiano.camerasync.firmware.FirmwareUpdateChecker
+import java.io.File
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+
+private const val TAG = "RicohFirmwareUpdateChecker"
+
+private val json = Json { ignoreUnknownKeys = true }
+
+// Hosted on GitHub Pages via the workflow
+private const val SCRAPED_JSON_URL =
+    "https://rock3r.github.io/RicohSync/firmware/ricoh_firmware.json"
+private const val JSON_CACHE_FILE = "ricoh_firmware_cache.json"
+private const val JSON_CACHE_VALIDITY_MS = 24 * 60 * 60 * 1000L // 24 hours
+
+// AWS API for newer models
+private const val AWS_API_URL =
+    "https://iazjp2ji87.execute-api.ap-northeast-1.amazonaws.com/v1/fwDownload"
+private const val AWS_API_KEY = "B1zN8uvCXN8QnN8t7rKExHKRLDKVm769qMebhera"
+private const val AWS_SECRET_KEY = "CySfvt88t8"
+
+class RicohFirmwareUpdateChecker(
+    private val context: Context,
+    /** Override for tests; null uses [AWS_API_URL]. */
+    private val awsApiUrl: String? = null,
+) : FirmwareUpdateChecker {
+
+    override fun supportsVendor(vendorId: String): Boolean = vendorId == "ricoh"
+
+    override suspend fun checkForUpdate(
+        device: PairedDevice,
+        currentFirmwareVersion: String?,
+    ): FirmwareUpdateCheckResult =
+        withContext(Dispatchers.IO) {
+            if (currentFirmwareVersion == null) {
+                return@withContext FirmwareUpdateCheckResult.CheckFailed(
+                    "Firmware version not available"
+                )
+            }
+
+            val modelName =
+                device.name
+                    ?: run {
+                        return@withContext FirmwareUpdateCheckResult.CheckFailed(
+                            "Device name not available"
+                        )
+                    }
+
+            // Determine which strategy to use
+            if (isLegacyModel(modelName)) {
+                checkForUpdateViaScrapedJson(modelName, currentFirmwareVersion)
+            } else {
+                checkForUpdateViaAwsApi(modelName, currentFirmwareVersion)
+            }
+        }
+
+    internal fun isLegacyModel(modelName: String): Boolean {
+        // Models that don't support the app API and need scraping
+        // Includes GR II, GR III series, GR IIIx series
+        val normalized = modelName.trim().uppercase()
+        return normalized.contains("GR II") ||
+            normalized.contains("GR III") ||
+            normalized.contains("GR IIIX")
+    }
+
+    // region Scraped JSON Strategy (Legacy)
+
+    private fun checkForUpdateViaScrapedJson(
+        modelName: String,
+        currentVersion: String,
+    ): FirmwareUpdateCheckResult {
+        val firmwareData =
+            getScrapedFirmwareData()
+                ?: return FirmwareUpdateCheckResult.CheckFailed("Could not fetch firmware data")
+
+        // Map app model name to scraped JSON key
+        // App uses "RICOH GR III", JSON might use "GR III"
+        // We search for the JSON key that is contained in the app model name.
+        // Iterate by key length descending so "GR IIIx" is matched before "GR III"
+        // (otherwise "RICOH GR IIIx".contains("GR III") would wrongly match GR III).
+        val cameras = firmwareData.cameras
+        if (cameras.isEmpty()) {
+            return FirmwareUpdateCheckResult.CheckFailed("Invalid firmware data format")
+        }
+
+        val match = findBestMatchingCameraKey(cameras, modelName)
+        val latestVersion = match?.second
+        val matchedModelKey = match?.first
+
+        if (latestVersion == null) {
+            return FirmwareUpdateCheckResult.CheckFailed(
+                "Model not found in firmware list: $modelName"
+            )
+        }
+
+        return if (isNewerVersion(latestVersion, currentVersion)) {
+            FirmwareUpdateCheckResult.UpdateAvailable(
+                currentVersion = currentVersion,
+                latestVersion = latestVersion,
+                modelName = matchedModelKey ?: modelName,
+            )
+        } else {
+            FirmwareUpdateCheckResult.NoUpdateAvailable
+        }
+    }
+
+    /**
+     * Finds the best-matching camera key and its firmware version for the given model name. Keys
+     * are tried in descending length order so that "GR IIIx" matches before "GR III".
+     */
+    internal fun findBestMatchingCameraKey(
+        cameras: Map<String, String>,
+        modelName: String,
+    ): Pair<String, String>? {
+        val keysByLengthDesc = cameras.keys.sortedByDescending { it.length }
+        for (key in keysByLengthDesc) {
+            if (modelName.contains(key, ignoreCase = true)) {
+                cameras[key]?.let { version ->
+                    return key to version
+                }
+            }
+        }
+        return null
+    }
+
+    private fun getScrapedFirmwareData(): RicohFirmwareData? {
+        val cacheFile = File(context.cacheDir, JSON_CACHE_FILE)
+
+        // Check cache
+        if (
+            cacheFile.exists() &&
+                System.currentTimeMillis() - cacheFile.lastModified() < JSON_CACHE_VALIDITY_MS
+        ) {
+            try {
+                return json.decodeFromString<RicohFirmwareData>(cacheFile.readText())
+            } catch (e: SerializationException) {
+                Log.warn(tag = TAG, throwable = e) { "Failed to read cached firmware data" }
+            } catch (e: IOException) {
+                Log.warn(tag = TAG, throwable = e) { "Failed to read cached firmware data" }
+            }
+        }
+
+        // Fetch from network
+        var connection: HttpURLConnection? = null
+        return try {
+            connection = URL(SCRAPED_JSON_URL).openConnection() as HttpURLConnection
+            connection.connectTimeout = 10000
+            connection.readTimeout = 10000
+
+            if (connection.responseCode != HttpURLConnection.HTTP_OK) {
+                Log.warn(tag = TAG) { "Failed to fetch firmware JSON: ${connection.responseCode}" }
+                return null
+            }
+
+            val jsonStr = connection.inputStream.bufferedReader().use { it.readText() }
+            val data = json.decodeFromString<RicohFirmwareData>(jsonStr)
+
+            // Save to cache
+            try {
+                cacheFile.writeText(jsonStr)
+            } catch (e: IOException) {
+                Log.warn(tag = TAG, throwable = e) { "Failed to cache firmware data" }
+            }
+
+            data
+        } catch (e: IOException) {
+            Log.warn(tag = TAG, throwable = e) { "Error fetching firmware JSON" }
+            null
+        } catch (e: SerializationException) {
+            Log.warn(tag = TAG, throwable = e) { "Error parsing firmware JSON" }
+            null
+        } finally {
+            connection?.disconnect()
+        }
+    }
+
+    // endregion
+
+    // region AWS API Strategy (Modern)
+
+    private fun checkForUpdateViaAwsApi(
+        modelName: String,
+        currentVersion: String,
+    ): FirmwareUpdateCheckResult {
+        // Map model name to API model code
+        val modelCode =
+            mapModelToApiCode(modelName)
+                ?: return FirmwareUpdateCheckResult.CheckFailed(
+                    "Unsupported model for API: $modelName"
+                )
+
+        var connection: HttpURLConnection? = null
+        return try {
+            connection = URL(awsApiUrl ?: AWS_API_URL).openConnection() as HttpURLConnection
+            connection.requestMethod = "POST"
+            connection.doOutput = true
+            connection.connectTimeout = 10000
+            connection.readTimeout = 10000
+
+            // Headers
+            connection.setRequestProperty("Content-Type", "application/json")
+            connection.setRequestProperty("x-api-key", AWS_API_KEY)
+            connection.setRequestProperty("x-secret-key", AWS_SECRET_KEY)
+
+            // Body (RICOH_PROTOCOL.md: minimal required fields + model)
+            val request =
+                RicohFirmwareApiRequest(
+                    phoneModel = android.os.Build.MODEL ?: "unknown",
+                    phoneOs = "Android",
+                    phoneOsVersion = android.os.Build.VERSION.RELEASE ?: "unknown",
+                    phoneLanguage = "en",
+                    phoneAppVer = "1.0.0",
+                    model = modelCode,
+                )
+            connection.outputStream.write(
+                json.encodeToString(RicohFirmwareApiRequest.serializer(), request).toByteArray()
+            )
+
+            if (connection.responseCode != HttpURLConnection.HTTP_OK) {
+                Log.warn(tag = TAG) { "AWS API error: ${connection.responseCode}" }
+                return FirmwareUpdateCheckResult.CheckFailed(
+                    "API error: ${connection.responseCode}"
+                )
+            }
+
+            val responseStr = connection.inputStream.bufferedReader().use { it.readText() }
+            val response = json.decodeFromString<RicohFirmwareApiResponse>(responseStr)
+
+            val latestVersion = response.version
+            if (latestVersion.isEmpty()) {
+                return FirmwareUpdateCheckResult.CheckFailed("Empty version in API response")
+            }
+
+            if (isNewerVersion(latestVersion, currentVersion)) {
+                FirmwareUpdateCheckResult.UpdateAvailable(
+                    currentVersion = currentVersion,
+                    latestVersion = latestVersion,
+                    modelName = modelName,
+                )
+            } else {
+                FirmwareUpdateCheckResult.NoUpdateAvailable
+            }
+        } catch (e: IOException) {
+            Log.warn(tag = TAG, throwable = e) { "Error checking AWS API" }
+            FirmwareUpdateCheckResult.CheckFailed("Network error: ${e.message}")
+        } catch (e: SerializationException) {
+            Log.warn(tag = TAG, throwable = e) { "Error parsing AWS API response" }
+            FirmwareUpdateCheckResult.CheckFailed(
+                "Could not parse firmware response: ${e.message ?: "invalid format"}"
+            )
+        } finally {
+            connection?.disconnect()
+        }
+    }
+
+    internal fun mapModelToApiCode(modelName: String): String? {
+        val name = modelName.trim()
+        return when {
+            name.contains("GR IV", ignoreCase = true) -> "gr4"
+            // Add other supported models for API here if any
+            else -> null
+        }
+    }
+
+    // endregion
+
+    internal fun isNewerVersion(latest: String, current: String): Boolean =
+        try {
+            val latestParts = latest.split(".").map { it.toInt() }
+            val currentParts = current.split(".").map { it.toInt() }
+
+            val length = maxOf(latestParts.size, currentParts.size)
+
+            for (i in 0 until length) {
+                val l = latestParts.getOrElse(i) { 0 }
+                val c = currentParts.getOrElse(i) { 0 }
+                if (l > c) return true
+                if (l < c) return false
+            }
+            false
+        } catch (e: NumberFormatException) {
+            Log.warn(TAG, e) { "Error parsing version numbers: $latest vs $current" }
+            false
+        }
+}

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/firmware/ricoh/RicohFirmwareUpdateCheckerTest.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/firmware/ricoh/RicohFirmwareUpdateCheckerTest.kt
@@ -1,0 +1,167 @@
+package dev.sebastiano.camerasync.firmware.ricoh
+
+import android.content.Context
+import dev.sebastiano.camerasync.domain.model.PairedDevice
+import dev.sebastiano.camerasync.firmware.FirmwareUpdateCheckResult
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class RicohFirmwareUpdateCheckerTest {
+
+    private lateinit var context: Context
+    private lateinit var checker: RicohFirmwareUpdateChecker
+
+    @Before
+    fun setUp() {
+        context = mockk(relaxed = true)
+        checker = RicohFirmwareUpdateChecker(context)
+    }
+
+    @Test
+    fun `supportsVendor returns true for ricoh vendor`() {
+        assertTrue(checker.supportsVendor("ricoh"))
+    }
+
+    @Test
+    fun `supportsVendor returns false for other vendors`() {
+        assertFalse(checker.supportsVendor("sony"))
+        assertFalse(checker.supportsVendor("canon"))
+    }
+
+    @Test
+    fun `isLegacyModel identifies legacy models correctly`() {
+        assertTrue(checker.isLegacyModel("RICOH GR II"))
+        assertTrue(checker.isLegacyModel("RICOH GR III"))
+        assertTrue(checker.isLegacyModel("RICOH GR IIIx"))
+        assertTrue(checker.isLegacyModel("GR III HDF"))
+        assertTrue(checker.isLegacyModel("GR IIIx HDF"))
+
+        assertFalse(checker.isLegacyModel("RICOH GR IV"))
+        assertFalse(checker.isLegacyModel("RICOH GR IV HDF"))
+        assertFalse(checker.isLegacyModel("Unknown Camera"))
+    }
+
+    @Test
+    fun `mapModelToApiCode maps modern models correctly`() {
+        assertEquals("gr4", checker.mapModelToApiCode("RICOH GR IV"))
+        assertEquals("gr4", checker.mapModelToApiCode("RICOH GR IV HDF"))
+        assertEquals("gr4", checker.mapModelToApiCode("GR IV"))
+
+        assertEquals(null, checker.mapModelToApiCode("RICOH GR III"))
+        assertEquals(null, checker.mapModelToApiCode("Unknown"))
+    }
+
+    @Test
+    fun `isNewerVersion compares versions correctly`() {
+        assertTrue(checker.isNewerVersion("2.00", "1.91"))
+        assertTrue(checker.isNewerVersion("1.0.1", "1.0.0"))
+        assertTrue(checker.isNewerVersion("2.0", "1.9.9"))
+
+        assertFalse(checker.isNewerVersion("1.91", "2.00"))
+        assertFalse(checker.isNewerVersion("1.0.0", "1.0.1"))
+        assertFalse(checker.isNewerVersion("1.0.0", "1.0.0"))
+    }
+
+    @Test
+    fun `checkForUpdate returns CheckFailed when firmware version is null`() = runTest {
+        val device =
+            PairedDevice(
+                macAddress = "AA:BB:CC:DD:EE:FF",
+                name = "RICOH GR III",
+                vendorId = "ricoh",
+                isEnabled = true,
+            )
+
+        val result = checker.checkForUpdate(device, null)
+
+        assertTrue(result is FirmwareUpdateCheckResult.CheckFailed)
+        assertEquals(
+            "Firmware version not available",
+            (result as FirmwareUpdateCheckResult.CheckFailed).reason,
+        )
+    }
+
+    @Test
+    fun `findBestMatchingCameraKey prefers longer key so GR IIIx matches GR IIIx not GR III`() {
+        val cameras = mapOf("GR III" to "1.91", "GR IIIx" to "2.00")
+        val match = checker.findBestMatchingCameraKey(cameras, "RICOH GR IIIx")
+        assertNotNull(match)
+        assertEquals("GR IIIx", match!!.first)
+        assertEquals("2.00", match.second)
+    }
+
+    @Test
+    fun `findBestMatchingCameraKey returns GR III for RICOH GR III`() {
+        val cameras = mapOf("GR III" to "1.91", "GR IIIx" to "2.00")
+        val match = checker.findBestMatchingCameraKey(cameras, "RICOH GR III")
+        assertNotNull(match)
+        assertEquals("GR III", match!!.first)
+        assertEquals("1.91", match.second)
+    }
+
+    @Test
+    fun `findBestMatchingCameraKey returns null when no key matches`() {
+        val cameras = mapOf("GR III" to "1.91")
+        val match = checker.findBestMatchingCameraKey(cameras, "Unknown Camera")
+        assertNull(match)
+    }
+
+    @Test
+    fun `checkForUpdate returns CheckFailed when device name is null`() = runTest {
+        val device =
+            PairedDevice(
+                macAddress = "AA:BB:CC:DD:EE:FF",
+                name = null,
+                vendorId = "ricoh",
+                isEnabled = true,
+            )
+
+        val result = checker.checkForUpdate(device, "1.00")
+
+        assertTrue(result is FirmwareUpdateCheckResult.CheckFailed)
+        assertEquals(
+            "Device name not available",
+            (result as FirmwareUpdateCheckResult.CheckFailed).reason,
+        )
+    }
+
+    @Test
+    fun `checkForUpdate returns CheckFailed with parsing message when AWS API returns malformed JSON`() =
+        runTest {
+            val server = MockWebServer()
+            server.start()
+            server.enqueue(MockResponse().setResponseCode(200).setBody("not valid json"))
+            val checkerWithMockServer =
+                RicohFirmwareUpdateChecker(context, awsApiUrl = server.url("/").toString())
+            val device =
+                PairedDevice(
+                    macAddress = "AA:BB:CC:DD:EE:FF",
+                    name = "RICOH GR IV",
+                    vendorId = "ricoh",
+                    isEnabled = true,
+                )
+
+            val result = checkerWithMockServer.checkForUpdate(device, "1.00")
+
+            server.shutdown()
+            assertTrue(result is FirmwareUpdateCheckResult.CheckFailed)
+            val reason = (result as FirmwareUpdateCheckResult.CheckFailed).reason
+            assertTrue(
+                "Reason should indicate parsing error, not network: $reason",
+                reason.startsWith("Could not parse firmware response:"),
+            )
+            assertFalse(
+                "Reason must not say network error for serialization failure: $reason",
+                reason.contains("Network error"),
+            )
+        }
+}

--- a/docs/ricoh/RICOH_PROTOCOL.md
+++ b/docs/ricoh/RICOH_PROTOCOL.md
@@ -1760,7 +1760,9 @@ If WLAN connection fails:
 
 ### 14.4. Firmware Update
 
-- [ ] Check cloud for latest version
+- [x] Check cloud for latest version (Hybrid strategy)
+    - **AWS API**: Used for newer models (e.g., GR IV).
+    - **Scraped Data**: Used for legacy models (GR II, GR III/IIIx). Fetched from `ricoh_firmware.json` hosted on GitHub Pages.
 - [ ] Compare with camera version
 - [ ] Download firmware binary
 - [ ] Upload to camera

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,10 +16,12 @@ kable = "0.42.0"
 khronicle = "0.6.0"
 ktfmt = "0.25.0"
 kotlin = "2.3.0"
+kotlinxSerialization = "1.10.0"
 lifecycle = "2.10.0"
 maplibre = "0.12.1"
 maplibre-spatialk = "0.6.1"
 mockk = "1.14.9"
+mockwebserver = "4.12.0"
 metro = "0.10.2"
 navigation3 = "1.0.0"
 protobufPlugin = "0.9.6"
@@ -58,7 +60,9 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 kable = { module = "com.juul.kable:kable-core", version.ref = "kable" }
 khronicle-core = { group = "com.juul.khronicle", name = "khronicle-core", version.ref = "khronicle" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockwebserver" }
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
 maplibre-core = { module = "org.maplibre.compose:maplibre-compose-android", version.ref = "maplibre" }
 maplibre-material3 = { module = "org.maplibre.compose:maplibre-compose-material3-android", version.ref = "maplibre" }
@@ -71,6 +75,7 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31.0
+beautifulsoup4>=4.12.0

--- a/scripts/scrape_ricoh_firmware.py
+++ b/scripts/scrape_ricoh_firmware.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Scrapes Ricoh Imaging website to extract latest firmware versions for Ricoh cameras.
+
+This script fetches firmware information from:
+https://www.ricoh-imaging.co.jp/english/support/download_digital.html
+
+It extracts firmware versions from tables under:
+- Firmware Update (Digital SL Cameras)
+- Firmware Update (Digital Compact Cameras)
+
+Outputs a JSON file with camera model names and their latest firmware versions.
+"""
+
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from typing import Dict
+
+import requests
+from bs4 import BeautifulSoup
+
+
+def normalize_model_name(model_name: str) -> str:
+    """
+    Normalize camera model names from the website to match app conventions.
+    
+    The website uses names like "GR III", "GR IIIx", etc.
+    The app may use "RICOH GR III", "RICOH GR IIIx", etc.
+    For now, we keep the website names as-is and let the app handle mapping.
+    """
+    # Remove extra whitespace
+    model_name = re.sub(r'\s+', ' ', model_name.strip())
+    
+    # Handle special cases if needed
+    # For example, website might have "GR III" but app expects "RICOH GR III"
+    # We'll keep it as-is for now and let the app handle the mapping
+    
+    return model_name
+
+
+def extract_firmware_from_table(table) -> Dict[str, str]:
+    """
+    Extract camera model names and firmware versions from a firmware table.
+    
+    Args:
+        table: BeautifulSoup table element
+        
+    Returns:
+        Dictionary mapping camera model names to firmware versions
+    """
+    cameras = {}
+    
+    # Find all rows in the table (skip header row)
+    rows = table.find_all('tr')[1:]  # Skip header row
+    
+    for row in rows:
+        cells = row.find_all('td')
+        if len(cells) >= 3:
+            # Column structure: Digital cameras | Content | Version
+            model_name = cells[0].get_text(strip=True)
+            version = cells[2].get_text(strip=True)
+            
+            if model_name and version:
+                normalized_name = normalize_model_name(model_name)
+                cameras[normalized_name] = version
+    
+    return cameras
+
+
+def scrape_ricoh_firmware() -> Dict[str, str]:
+    """
+    Scrape Ricoh Imaging website for firmware versions.
+    
+    Returns:
+        Dictionary mapping camera model names to firmware versions
+    """
+    url = "https://www.ricoh-imaging.co.jp/english/support/download_digital.html"
+    
+    print(f"Fetching {url}...")
+    try:
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        print(f"Error fetching website: {e}", file=sys.stderr)
+        sys.exit(1)
+    
+    soup = BeautifulSoup(response.content, 'html.parser')
+    
+    all_cameras = {}
+    
+    # Find all headings (h4, h5, h6) that contain "Firmware Update"
+    headings = soup.find_all(['h4', 'h5', 'h6'])
+    
+    for heading in headings:
+        heading_text = heading.get_text(strip=True)
+        
+        # Look for firmware update sections
+        if 'Firmware Update' in heading_text and 'Digital' in heading_text:
+            # Find the next table after this heading using find_next
+            table = heading.find_next('table')
+            if table:
+                print(f"Processing table under: {heading_text}")
+                cameras = extract_firmware_from_table(table)
+                all_cameras.update(cameras)
+    
+    if not all_cameras:
+        print("Warning: No firmware data found. Website structure may have changed.", file=sys.stderr)
+    
+    return all_cameras
+
+
+def main():
+    """Main entry point."""
+    print("Scraping Ricoh firmware versions...")
+
+    cameras = scrape_ricoh_firmware()
+
+    if not cameras:
+        print(
+            "Error: No firmware data found. Website structure may have changed. Refusing to deploy empty data.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Generate output JSON
+    output = {
+        "last_updated": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "cameras": cameras,
+    }
+
+    # Write to file
+    output_file = "ricoh_firmware.json"
+    with open(output_file, "w", encoding="utf-8") as f:
+        json.dump(output, f, indent=2, ensure_ascii=False)
+
+    print(f"\nFound {len(cameras)} camera models with firmware versions")
+    print(f"Output written to {output_file}")
+
+    # Print summary of GR models (most relevant for this app)
+    gr_models = {k: v for k, v in cameras.items() if "GR" in k.upper()}
+    if gr_models:
+        print("\nGR Series firmware versions:")
+        for model, version in sorted(gr_models.items()):
+            print(f"  {model}: {version}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Introduced `RicohFirmwareUpdateChecker` to support firmware update checks for Ricoh devices using a hybrid approach.
- Implemented an AWS API strategy for modern models (e.g., GR IV) using secure POST requests.
- Implemented a scraped JSON strategy for legacy models (GR II, GR III/IIIx) that fetches data from a GitHub Pages hosted resource.
- Added a Python-based scraping script and a GitHub Action workflow to automatically update legacy firmware data daily.
- Integrated `RicohFirmwareUpdateChecker` into the application dependency graph.
- Added comprehensive unit tests for version comparison, model mapping, and update detection logic.

These changes enable automated firmware update notifications for Ricoh camera users, supporting both legacy and modern device protocols.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds new network-based firmware-update logic and a scheduled GitHub Pages data pipeline; failures or API changes could cause incorrect update status or background check errors. Also embeds third-party API keys in the client and introduces external dependencies (AWS endpoint + scraped website/Pages) that can break unexpectedly.
> 
> **Overview**
> Adds **Ricoh firmware update checking** via a new `RicohFirmwareUpdateChecker`, wired into DI alongside the existing Sony checker. It uses a *hybrid strategy*: legacy GR II/GR III/GR IIIx models fetch and cache a scraped `ricoh_firmware.json` from GitHub Pages, while newer models (currently GR IV) call Ricoh’s AWS `fwDownload` API and compare semantic-ish version strings.
> 
> Introduces the supporting plumbing: Kotlin serialization + JSON models, unit tests (including MockWebServer coverage for malformed API responses), and a scheduled GitHub Action plus Python scraper to refresh and publish the legacy firmware JSON daily. Generated JSON and the `deploy/` directory are now ignored by git, and protocol docs are updated to mark the hybrid firmware check as implemented.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b5231addd0f9755938cdc68ce10fd8610ef037a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->