### PR TITLE
Enhance LogViewer functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A simple Android application that synchronizes GPS data and date/time from your Android phone to
 your camera via Bluetooth Low Energy (BLE).
 
-The app supports a multi-vendor architecture, allowing it to work with cameras from various
+The app supports a multivendor architecture, allowing it to work with cameras from various
 manufacturers (Ricoh, Sony, etc.).
 
 The app uses Android's system pairing flow to select your camera on first start. Once paired, it

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/logging/LogViewerScreen.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/logging/LogViewerScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -31,10 +32,12 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -189,7 +192,17 @@ fun LogViewerScreen(viewModel: LogViewerViewModel, onNavigateBack: () -> Unit) {
                 }
             }
 
+            val listState = rememberLazyListState()
+            val hasScrolledToEnd = rememberSaveable { mutableStateOf(false) }
+            LaunchedEffect(logs.size) {
+                if (logs.isNotEmpty() && !hasScrolledToEnd.value) {
+                    listState.animateScrollToItem(logs.size - 1)
+                    hasScrolledToEnd.value = true
+                }
+            }
+
             LazyColumn(
+                state = listState,
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(bottom = 16.dp),
             ) {

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/logging/LogcatLogRepository.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/logging/LogcatLogRepository.kt
@@ -11,6 +11,52 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 
+/**
+ * Parses logcat -v threadtime output into [LogEntry] list. Internal for unit testing; used by
+ * [LogcatLogRepository].
+ */
+internal object LogcatLogParser {
+
+    // Regex for logcat -v threadtime:
+    // 01-24 16:35:45.321  1234  5678 I Tag: message
+    private val logRegex =
+        Regex(
+            """^(\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3})\s+(\d+)\s+(\d+)\s([VDIWEA])\s+(.*?):\s?(.*)$"""
+        )
+
+    // logcat -d outputs buffer separator lines that don't match logRegex (e.g. "--------- beginning
+    // of main")
+    private const val BUFFER_SEPARATOR_PREFIX = "--------- beginning of"
+
+    fun parseLines(lines: Sequence<String>): List<LogEntry> {
+        val newLogs = mutableListOf<LogEntry>()
+        for (line in lines) {
+            val match = logRegex.matchEntire(line)
+            if (match != null) {
+                val g = match.groupValues
+                newLogs.add(
+                    LogEntry(
+                        timestamp = g[1],
+                        level = LogLevel.fromLogcat(g[4]),
+                        tag = g[5].trim(),
+                        message = g[6],
+                        pid = g[2].toIntOrNull(),
+                        tid = g[3].toIntOrNull(),
+                    )
+                )
+            } else if (!line.startsWith(BUFFER_SEPARATOR_PREFIX)) {
+                // Continuation line (e.g. stack trace): append to previous entry.
+                if (newLogs.isNotEmpty()) {
+                    val last = newLogs.removeAt(newLogs.size - 1)
+                    newLogs.add(last.copy(message = last.message + "\n" + line))
+                }
+            }
+            // else: buffer separator line, skip
+        }
+        return newLogs
+    }
+}
+
 /** Implementation of [LogRepository] that reads from Android's logcat. */
 class LogcatLogRepository(context: Context) : LogRepository {
 
@@ -20,46 +66,12 @@ class LogcatLogRepository(context: Context) : LogRepository {
 
     override fun getLogs(): Flow<List<LogEntry>> = _logs.asStateFlow()
 
-    // Regex for logcat -v threadtime:
-    // 01-24 16:35:45.321  1234  5678 I Tag: message
-    private val logRegex =
-        Regex(
-            """^(\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3})\s+(\d+)\s+(\d+)\s([VDIWEA])\s+(.*?):\s?(.*)$"""
-        )
-
     override suspend fun refresh() {
         withContext(Dispatchers.IO) {
             try {
-                // Using -v threadtime for consistent parsing
                 val process = Runtime.getRuntime().exec(arrayOf("logcat", "-d", "-v", "threadtime"))
                 val reader = BufferedReader(InputStreamReader(process.inputStream))
-                val newLogs = mutableListOf<LogEntry>()
-
-                reader.forEachLine { line ->
-                    val match = logRegex.matchEntire(line)
-                    if (match != null) {
-                        val g = match.groupValues
-                        val timestamp = g[1]
-                        val pid = g[2]
-                        val tid = g[3]
-                        val level = g[4]
-                        val tag = g[5]
-                        val message = g[6]
-                        newLogs.add(
-                            LogEntry(
-                                timestamp = timestamp,
-                                level = LogLevel.fromLogcat(level),
-                                tag = tag.trim(),
-                                message = message,
-                                pid = pid.toIntOrNull(),
-                                tid = tid.toIntOrNull(),
-                            )
-                        )
-                    }
-                }
-
-                // We want newest logs first in the viewer
-                _logs.value = newLogs.reversed()
+                _logs.value = reader.useLines { LogcatLogParser.parseLines(it) }
             } catch (e: IOException) {
                 Log.warn("LogcatLogRepository", throwable = e) {
                     "Failed to refresh logs for $packageName"

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/logging/LogcatLogParserTest.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/logging/LogcatLogParserTest.kt
@@ -1,0 +1,129 @@
+package dev.sebastiano.camerasync.logging
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/** Unit tests for [LogcatLogParser] (logcat -v threadtime parsing). */
+class LogcatLogParserTest {
+
+    private fun parse(vararg lines: String): List<LogEntry> =
+        LogcatLogParser.parseLines(lines.asSequence())
+
+    @Test
+    fun `empty input returns empty list`() {
+        assertEquals(emptyList<LogEntry>(), parse())
+    }
+
+    @Test
+    fun `single valid log line is parsed`() {
+        val lines = arrayOf("01-24 16:35:45.321  1234  5678 I MyTag: Hello world")
+        val result = parse(*lines)
+        assertEquals(1, result.size)
+        assertEquals("01-24 16:35:45.321", result[0].timestamp)
+        assertEquals(LogLevel.INFO, result[0].level)
+        assertEquals("MyTag", result[0].tag)
+        assertEquals("Hello world", result[0].message)
+        assertEquals(1234, result[0].pid)
+        assertEquals(5678, result[0].tid)
+    }
+
+    @Test
+    fun `buffer separator lines are skipped and not appended to previous entry`() {
+        val lines =
+            arrayOf(
+                "01-24 16:35:45.321  1234  5678 I Tag: actual message",
+                "--------- beginning of system",
+            )
+        val result = parse(*lines)
+        assertEquals(1, result.size)
+        assertEquals("actual message", result[0].message)
+        assertFalse(result[0].message.contains("---------"))
+    }
+
+    @Test
+    fun `buffer separator beginning of main is skipped`() {
+        val lines =
+            arrayOf("--------- beginning of main", "01-24 16:35:45.321  1234  5678 I Tag: first")
+        val result = parse(*lines)
+        assertEquals(1, result.size)
+        assertEquals("first", result[0].message)
+    }
+
+    @Test
+    fun `multiple buffer separators between entries do not pollute messages`() {
+        val lines =
+            arrayOf(
+                "01-24 16:35:45.321  1234  5678 I Tag: first",
+                "--------- beginning of main",
+                "--------- beginning of system",
+                "01-24 16:35:46.000  1234  5678 W Tag: second",
+            )
+        val result = parse(*lines)
+        assertEquals(2, result.size)
+        assertEquals("first", result[0].message)
+        assertEquals("second", result[1].message)
+    }
+
+    @Test
+    fun `continuation line is appended to previous entry`() {
+        val lines =
+            arrayOf(
+                "01-24 16:35:45.321  1234  5678 E Tag: Exception",
+                "    at com.example.Foo.bar(Foo.kt:42)",
+            )
+        val result = parse(*lines)
+        assertEquals(1, result.size)
+        assertEquals("Exception\n    at com.example.Foo.bar(Foo.kt:42)", result[0].message)
+    }
+
+    @Test
+    fun `multiple continuation lines append to same entry`() {
+        val lines =
+            arrayOf(
+                "01-24 16:35:45.321  1234  5678 E Tag: Caused by:",
+                "    at foo.Bar.baz(Bar.kt:1)",
+                "    at foo.Bar.qux(Bar.kt:2)",
+            )
+        val result = parse(*lines)
+        assertEquals(1, result.size)
+        assertEquals(
+            "Caused by:\n    at foo.Bar.baz(Bar.kt:1)\n    at foo.Bar.qux(Bar.kt:2)",
+            result[0].message,
+        )
+    }
+
+    @Test
+    fun `continuation after buffer separator appends to next log not previous`() {
+        val lines =
+            arrayOf(
+                "01-24 16:35:45.321  1234  5678 I Tag: before separator",
+                "--------- beginning of crash",
+                "01-24 16:35:46.000  1234  5678 E Tag: after separator",
+                "    stack trace line",
+            )
+        val result = parse(*lines)
+        assertEquals(2, result.size)
+        assertEquals("before separator", result[0].message)
+        assertEquals("after separator\n    stack trace line", result[1].message)
+    }
+
+    @Test
+    fun `all log levels parsed`() {
+        val levels = listOf("V", "D", "I", "W", "E", "A")
+        val expected =
+            listOf(
+                LogLevel.VERBOSE,
+                LogLevel.DEBUG,
+                LogLevel.INFO,
+                LogLevel.WARN,
+                LogLevel.ERROR,
+                LogLevel.ASSERT,
+            )
+        levels.zip(expected).forEach { (letter, level) ->
+            val result = parse("01-24 16:35:45.321  1  2 $letter Tag: msg")
+            assertEquals(1, result.size)
+            assertEquals(level, result[0].level)
+        }
+    }
+}


### PR DESCRIPTION
- Modified `LogcatLogRepository` to return logs in ascending chronological order and improved parsing to handle multi-line entries like stack traces.
- Updated `LogViewerScreen` to utilize `rememberLazyListState` and implement an initial scroll-to-bottom behavior using `LaunchedEffect`.
- Improved log readability by appending continuation lines to their parent log entries.

These changes ensure that logs are displayed in a more natural chronological flow while ensuring the most recent entries are immediately visible upon loading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes log parsing/order and UI scrolling behavior, which can affect log visibility and performance but is not security- or data-critical.
> 
> **Overview**
> Improves the in-app log viewer by adding an initial *scroll-to-latest* behavior via `rememberLazyListState` + `LaunchedEffect`, without forcing subsequent auto-scrolling.
> 
> Refactors logcat ingestion by extracting a testable `LogcatLogParser` that skips logcat buffer separator lines and folds multi-line continuations (e.g., stack traces) into the previous `LogEntry`, and updates `LogcatLogRepository.refresh()` to use it. Adds unit tests covering parsing, continuation handling, and all log levels, plus a small README wording tweak ("multi-vendor" -> "multivendor").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 940cab890ac2cd2a6fbd2a0269351c3bf2748121. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->