### PR TITLE
Enhance Sony camera synchronization protocol and location data management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ deploy/
 
 # Python virtual environment
 scripts/.venv/
+
+/dumps/

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/CameraSyncApp.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/CameraSyncApp.kt
@@ -35,6 +35,10 @@ class CameraSyncApp : Application() {
         // Initialize Khronicle logging early in application lifecycle
         initializeLogging()
 
+        Log.info(javaClass.simpleName) {
+            "-------------------- CAMERASYNC STARTED --------------------"
+        }
+
         // Register notification channels early so they're available before any service tries to use
         // them
         registerNotificationChannel(this)

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/data/repository/KableCameraRepository.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/data/repository/KableCameraRepository.kt
@@ -21,18 +21,30 @@ import dev.sebastiano.camerasync.domain.repository.CameraConnection
 import dev.sebastiano.camerasync.domain.repository.CameraRepository
 import dev.sebastiano.camerasync.domain.vendor.CameraVendorRegistry
 import dev.sebastiano.camerasync.logging.KhronicleLogEngine
+import dev.sebastiano.camerasync.vendors.sony.SonyCameraVendor
+import dev.sebastiano.camerasync.vendors.sony.SonyGattSpec
+import dev.sebastiano.camerasync.vendors.sony.SonyProtocol
 import java.io.IOException
 import java.time.ZonedDateTime
 import kotlin.uuid.ExperimentalUuidApi
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 
 private const val TAG = "KableCameraRepository"
+
+/** MTU size for Sony cameras (per Sony Creators' App which requests MTU 158). */
+private const val SONY_MTU_SIZE = 158
 
 /**
  * Implementation of [CameraRepository] using the Kable BLE library.
@@ -221,6 +233,23 @@ class KableCameraRepository(
                             engine = KhronicleLogEngine
                             identifier = "CameraSync:${camera.vendor.vendorName}"
                         }
+                        // Sony cameras require MTU 158 (per Sony Creators' App)
+                        if (camera.vendor.vendorId == "sony") {
+                            onServicesDiscovered {
+                                @Suppress("TooGenericExceptionCaught")
+                                try {
+                                    requestMtu(SONY_MTU_SIZE)
+                                    Log.info(tag = TAG) {
+                                        "Sony MTU request successful: $SONY_MTU_SIZE"
+                                    }
+                                } catch (e: Exception) {
+                                    // MTU request failure is not critical - continue anyway
+                                    Log.warn(tag = TAG, throwable = e) {
+                                        "Failed to request MTU $SONY_MTU_SIZE, continuing with default"
+                                    }
+                                }
+                            }
+                        }
                     }
 
                 Log.info(tag = TAG) { "Connecting to ${camera.name}..." }
@@ -308,12 +337,32 @@ class KableCameraRepository(
             return null
         }
 
+        // Parse BLE protocol version for Sony cameras
+        val protocolVersion =
+            if (vendor.vendorId == "sony") {
+                SonyCameraVendor.parseProtocolVersion(mfrData).also { version ->
+                    if (version != null) {
+                        Log.info(tag = TAG) {
+                            "Sony camera $peripheralName BLE protocol version: $version" +
+                                if (version >= SonyCameraVendor.PROTOCOL_VERSION_REQUIRES_UNLOCK) {
+                                    " (requires DD30/DD31 unlock)"
+                                } else {
+                                    " (legacy protocol)"
+                                }
+                        }
+                    }
+                }
+            } else {
+                null
+            }
+
         Log.info(tag = TAG) { "Discovered ${vendor.vendorName} camera: $peripheralName" }
         return Camera(
             identifier = identifier,
             name = peripheralName,
             macAddress = identifier, // On Android, identifier is the MAC address
             vendor = vendor,
+            bleProtocolVersion = protocolVersion,
         )
     }
 }
@@ -323,6 +372,11 @@ class KableCameraRepository(
  *
  * This implementation is vendor-agnostic and uses the camera's vendor specification to interact
  * with the camera's BLE services.
+ *
+ * Sony protocol specifics (see docs/sony/DATETIME_GPS_SYNC.md):
+ * - All BLE write operations have a 30-second timeout
+ * - Location writes (DD11) are retried up to 3 times on failure
+ * - Capabilities must be read from DD21/DD32/DD33 before location sync
  */
 @OptIn(ExperimentalUuidApi::class)
 internal class KableCameraConnection(
@@ -335,6 +389,62 @@ internal class KableCameraConnection(
     private val gattSpec = camera.vendor.gattSpec
     private val protocol = camera.vendor.protocol
     private val capabilities = camera.vendor.getCapabilities()
+
+    /**
+     * Tracks whether the Sony location service unlock sequence (DD30/DD31) has been performed. This
+     * is required for Sony cameras with BLE protocol version >= 65 (newer protocol). The
+     * characteristics only exist on cameras that need them.
+     */
+    private var sonyLocationServiceEnabled = false
+
+    /**
+     * Cached Sony camera capabilities read from DD21. Used to determine if timezone data should be
+     * included in location packets.
+     */
+    private var sonyCapabilities: SonyCapabilities? = null
+
+    /**
+     * Job for observing DD01 (Location Status Notify) characteristic notifications. Must be
+     * cancelled when disconnecting to prevent resource leaks.
+     */
+    private var sonyNotificationObservationJob: Job? = null
+
+    /**
+     * Holds Sony-specific camera capabilities read from GATT characteristics.
+     *
+     * @param requiresTimezone Whether the camera requires timezone data in location packets (from
+     *   DD21)
+     * @param timeCorrection Raw time correction data (from DD32)
+     * @param areaAdjustment Raw area adjustment data (from DD33)
+     */
+    private data class SonyCapabilities(
+        val requiresTimezone: Boolean,
+        val timeCorrection: ByteArray? = null,
+        val areaAdjustment: ByteArray? = null,
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+            other as SonyCapabilities
+            if (requiresTimezone != other.requiresTimezone) return false
+            if (timeCorrection != null) {
+                if (other.timeCorrection == null) return false
+                if (!timeCorrection.contentEquals(other.timeCorrection)) return false
+            } else if (other.timeCorrection != null) return false
+            if (areaAdjustment != null) {
+                if (other.areaAdjustment == null) return false
+                if (!areaAdjustment.contentEquals(other.areaAdjustment)) return false
+            } else if (other.areaAdjustment != null) return false
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = requiresTimezone.hashCode()
+            result = 31 * result + (timeCorrection?.contentHashCode() ?: 0)
+            result = 31 * result + (areaAdjustment?.contentHashCode() ?: 0)
+            return result
+        }
+    }
 
     override suspend fun initializePairing(): Boolean {
         if (!capabilities.requiresVendorPairing) {
@@ -490,6 +600,11 @@ internal class KableCameraConnection(
         )
     }
 
+    /**
+     * Syncs date/time to the camera.
+     *
+     * Per Sony protocol spec, all BLE write operations have a 30-second timeout.
+     */
     override suspend fun syncDateTime(dateTime: ZonedDateTime) {
         if (!capabilities.supportsDateTimeSync) {
             throw UnsupportedOperationException(
@@ -509,7 +624,9 @@ internal class KableCameraConnection(
 
         val data = protocol.encodeDateTime(dateTime)
         Log.info(tag = TAG) { "Syncing date/time: ${protocol.decodeDateTime(data)}" }
-        peripheral.write(char, data, locationWriteType())
+
+        // Per spec: 30-second timeout for BLE write operations
+        withTimeout(BLE_WRITE_TIMEOUT_MS) { peripheral.write(char, data, locationWriteType()) }
     }
 
     override suspend fun readDateTime(): ByteArray {
@@ -587,6 +704,13 @@ internal class KableCameraConnection(
         return enabled
     }
 
+    /**
+     * Syncs a GPS location to the camera.
+     *
+     * Per Sony protocol spec:
+     * - All BLE write operations have a 30-second timeout
+     * - Write failures to DD11 are retried up to 3 times
+     */
     override suspend fun syncLocation(location: GpsLocation) {
         if (!capabilities.supportsLocationSync) {
             throw UnsupportedOperationException(
@@ -604,6 +728,20 @@ internal class KableCameraConnection(
                         "Available services: ${peripheral.services.value?.map { it.serviceUuid } ?: "N/A"}"
                 )
 
+        // For Sony cameras, re-enable location service before EVERY write.
+        // The camera appears to have an internal session timeout that invalidates
+        // the DD30/DD31 lock after some period, causing the 🚫 icon to appear.
+        // Re-enabling ensures the camera is always ready to receive location data.
+        if (camera.vendor.vendorId == "sony") {
+            if (!sonyLocationServiceEnabled) {
+                Log.info(tag = TAG) {
+                    "Sony location service characteristics for ${camera.macAddress}: " +
+                        service.characteristics.map { it.characteristicUuid }
+                }
+            }
+            enableSonyLocationService(service)
+        }
+
         val char =
             service.characteristics.firstOrNull {
                 it.characteristicUuid == gattSpec.locationCharacteristicUuid
@@ -613,24 +751,422 @@ internal class KableCameraConnection(
                         "Available characteristics in service ${service.serviceUuid}: ${service.characteristics.map { it.characteristicUuid }}"
                 )
 
-        val data = protocol.encodeLocation(location)
+        // For Sony cameras, use the capabilities-based timezone setting from DD21
+        val data =
+            if (camera.vendor.vendorId == "sony") {
+                val includeTimezone = sonyCapabilities?.requiresTimezone ?: true
+                Log.debug(tag = TAG) {
+                    "Sony location packet: includeTimezone=$includeTimezone " +
+                        "(packet size: ${if (includeTimezone) 95 else 91} bytes)"
+                }
+                val packet =
+                    SonyProtocol.encodeLocationPacket(
+                        latitude = location.latitude,
+                        longitude = location.longitude,
+                        dateTime = location.timestamp,
+                        includeTimezone = includeTimezone,
+                    )
+                // Enhanced logging for debugging Sony protocol
+                val utcTime = location.timestamp.withZoneSameInstant(java.time.ZoneOffset.UTC)
+                Log.info(tag = TAG) {
+                    "Sony DD11 encoding: UTC=${utcTime.year}-${utcTime.monthValue.toString().padStart(2, '0')}-" +
+                        "${utcTime.dayOfMonth.toString().padStart(2, '0')} ${utcTime.hour.toString().padStart(2, '0')}:" +
+                        "${utcTime.minute.toString().padStart(2, '0')}:${utcTime.second.toString().padStart(2, '0')}, " +
+                        "Lat=${location.latitude}, Lon=${location.longitude}"
+                }
+                // Log header bytes (0-10) for debugging
+                Log.info(tag = TAG) {
+                    "Sony DD11 header (bytes 0-10): ${packet.take(11).toByteArray().toHexString()}"
+                }
+                // Log coordinates and time (bytes 11-25)
+                Log.info(tag = TAG) {
+                    "Sony DD11 coords+time (bytes 11-25): ${packet.slice(11..25).toByteArray().toHexString()}"
+                }
+                // Log timezone bytes if included (bytes 91-94)
+                if (includeTimezone && packet.size >= 95) {
+                    Log.info(tag = TAG) {
+                        "Sony DD11 TZ bytes (91-94): ${packet.slice(91..94).toByteArray().toHexString()}"
+                    }
+                }
+                Log.info(tag = TAG) { "Sony DD11 packet total size: ${packet.size} bytes" }
+                packet
+            } else {
+                protocol.encodeLocation(location)
+            }
         Log.info(tag = TAG) { "Syncing location: ${protocol.decodeLocation(data)}" }
-        peripheral.write(char, data, locationWriteType())
+
+        // For Sony cameras, implement retry logic (3 retries per spec)
+        if (camera.vendor.vendorId == "sony") {
+            writeLocationWithRetry(char, data)
+        } else {
+            withTimeout(BLE_WRITE_TIMEOUT_MS) { peripheral.write(char, data, locationWriteType()) }
+        }
+    }
+
+    /**
+     * Writes location data with retry logic for Sony cameras.
+     *
+     * Per Sony protocol spec: Write failures to DD11 are retried up to 3 times.
+     *
+     * @param char The characteristic to write to (DD11)
+     * @param data The location data payload
+     * @throws IOException if all retries fail
+     */
+    private suspend fun writeLocationWithRetry(
+        char: com.juul.kable.DiscoveredCharacteristic,
+        data: ByteArray,
+    ) {
+        var lastException: Exception? = null
+        repeat(LOCATION_WRITE_MAX_RETRIES) { attempt ->
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                withTimeout(BLE_WRITE_TIMEOUT_MS) {
+                    peripheral.write(char, data, locationWriteType())
+                }
+                Log.debug(tag = TAG) { "Location write succeeded on attempt ${attempt + 1}" }
+                return
+            } catch (e: TimeoutCancellationException) {
+                Log.warn(tag = TAG) {
+                    "Location write timed out on attempt ${attempt + 1}/$LOCATION_WRITE_MAX_RETRIES"
+                }
+                lastException = e
+            } catch (e: IOException) {
+                Log.warn(tag = TAG, throwable = e) {
+                    "Location write failed on attempt ${attempt + 1}/$LOCATION_WRITE_MAX_RETRIES"
+                }
+                lastException = e
+            } catch (e: CancellationException) {
+                // Preserve structured concurrency - don't catch cancellation
+                throw e
+            } catch (e: Exception) {
+                Log.error(tag = TAG, throwable = e) {
+                    "Unexpected error on location write attempt ${attempt + 1}/$LOCATION_WRITE_MAX_RETRIES"
+                }
+                lastException = e
+            }
+
+            // Small delay before retry
+            if (attempt < LOCATION_WRITE_MAX_RETRIES - 1) {
+                delay(500)
+            }
+        }
+
+        throw IOException(
+            "Location write failed after $LOCATION_WRITE_MAX_RETRIES attempts",
+            lastException,
+        )
+    }
+
+    /**
+     * Enables the Sony location service by writing to DD30 (Lock) and DD31 (Enable)
+     * characteristics, then reading camera capabilities from DD21, DD32, and DD33.
+     *
+     * Per Sony protocol spec (see docs/sony/DATETIME_GPS_SYNC.md):
+     * 1. Lock Session: Write { 0x01 } to DD30
+     * 2. Enable Transfer: Write { 0x01 } to DD31
+     * 3. Read Capabilities: Read DD21 (Camera Info), DD32 (Time Correction), DD33 (Area Adjustment)
+     *
+     * This is required for Sony cameras with BLE protocol version >= 65 (typically firmware 3.02+,
+     * but also newer camera models like Alpha 7 IV even with earlier firmware versions).
+     *
+     * The function checks both the protocol version from advertisement data AND whether DD30/DD31
+     * characteristics actually exist (as a fallback for when advertisement data wasn't available).
+     */
+    private suspend fun enableSonyLocationService(service: com.juul.kable.DiscoveredService) {
+        val isFirstEnable = !sonyLocationServiceEnabled
+        val protocolVersion = camera.bleProtocolVersion
+        val requiresUnlock =
+            protocolVersion != null &&
+                protocolVersion >= SonyCameraVendor.PROTOCOL_VERSION_REQUIRES_UNLOCK
+
+        // Find DD30 (Lock Location Endpoint) characteristic
+        val lockChar =
+            service.characteristics.firstOrNull {
+                it.characteristicUuid == SonyGattSpec.LOCATION_LOCK_CHARACTERISTIC_UUID
+            }
+
+        // Find DD31 (Enable Location Update) characteristic
+        val enableChar =
+            service.characteristics.firstOrNull {
+                it.characteristicUuid == SonyGattSpec.LOCATION_ENABLE_CHARACTERISTIC_UUID
+            }
+
+        val hasUnlockChars = lockChar != null && enableChar != null
+
+        // Log protocol version info (only on first enable)
+        if (isFirstEnable) {
+            Log.info(tag = TAG) {
+                "Sony camera ${camera.macAddress}: protocol version=$protocolVersion, " +
+                    "requires unlock=$requiresUnlock, has DD30/DD31=$hasUnlockChars"
+            }
+        }
+
+        // If DD30/DD31 don't exist, this camera uses the older protocol - no action needed
+        if (!hasUnlockChars) {
+            if (isFirstEnable) {
+                if (requiresUnlock) {
+                    Log.warn(tag = TAG) {
+                        "Sony camera ${camera.macAddress} protocol version $protocolVersion requires " +
+                            "DD30/DD31 unlock but characteristics not found! Location sync may not work."
+                    }
+                } else {
+                    Log.debug(tag = TAG) {
+                        "Sony camera ${camera.macAddress} uses legacy protocol (no unlock required)"
+                    }
+                }
+                // Read capabilities even for legacy protocol (if available)
+                sonyCapabilities = readSonyCapabilities(service)
+            }
+            sonyLocationServiceEnabled = true
+            return
+        }
+
+        // Even if protocol version < 65, if DD30/DD31 exist, use them (defensive approach)
+        // At this point we know both lockChar and enableChar are non-null (hasUnlockChars == true)
+        if (isFirstEnable) {
+            Log.info(tag = TAG) {
+                "Enabling Sony location service for ${camera.macAddress} via DD30/DD31 unlock sequence"
+            }
+        } else {
+            Log.debug(tag = TAG) {
+                "Re-enabling Sony location service for ${camera.macAddress} (keep-alive)"
+            }
+        }
+
+        // Phase 1, Step 0: Subscribe to DD01 notifications FIRST (per Sony decompiled code)
+        // Only subscribe on first enable - subscription persists across re-enables
+        if (isFirstEnable) {
+            val notifyChar =
+                service.characteristics.firstOrNull {
+                    it.characteristicUuid == SonyGattSpec.LOCATION_STATUS_NOTIFY_CHARACTERISTIC_UUID
+                }
+            if (notifyChar != null) {
+                Log.debug(tag = TAG) { "Subscribing to DD01 notifications" }
+                @Suppress("TooGenericExceptionCaught")
+                try {
+                    // Cancel any existing observation job before starting a new one
+                    sonyNotificationObservationJob?.cancel()
+                    // Start observing DD01 in a background coroutine
+                    // This enables notifications (writes CCCD) and collects status updates
+                    // Use SupervisorJob so cancellation can be controlled independently
+                    val supervisorJob = SupervisorJob(currentCoroutineContext()[Job])
+                    val observeScope = CoroutineScope(currentCoroutineContext() + supervisorJob)
+                    sonyNotificationObservationJob = supervisorJob
+                    observeScope.launch {
+                        peripheral.observe(notifyChar).collect { data ->
+                            Log.info(tag = TAG) {
+                                "DD01 notification received: ${data.toHexString()}"
+                            }
+                            // Check for LOCATION_TRANSFER_DISABLE (camera turned off location)
+                            if (data.contentEquals(byteArrayOf(0x00))) {
+                                Log.warn(tag = TAG) {
+                                    "Camera disabled location transfer (DD01 = 0x00)"
+                                }
+                            }
+                        }
+                    }
+                    // Give time for the CCCD write to complete
+                    delay(100)
+                } catch (e: Exception) {
+                    // Non-fatal: continue even if subscription fails
+                    Log.warn(tag = TAG, throwable = e) {
+                        "Failed to subscribe to DD01, continuing anyway"
+                    }
+                }
+            } else {
+                Log.debug(tag = TAG) {
+                    "DD01 (Status Notify) characteristic not found, skipping subscription"
+                }
+            }
+        }
+
+        // Phase 1, Step 1: Lock Session - Write 0x01 to DD30
+        // Always re-write to keep the session alive
+        Log.debug(tag = TAG) { "Writing 0x01 to DD30 (Lock Session)" }
+        withTimeout(BLE_WRITE_TIMEOUT_MS) {
+            peripheral.write(lockChar, byteArrayOf(0x01), WriteType.WithResponse)
+        }
+
+        // Phase 1, Step 2: Enable Transfer - Write 0x01 to DD31
+        // Always re-write to keep the transfer enabled
+        Log.debug(tag = TAG) { "Writing 0x01 to DD31 (Enable Transfer)" }
+        withTimeout(BLE_WRITE_TIMEOUT_MS) {
+            peripheral.write(enableChar, byteArrayOf(0x01), WriteType.WithResponse)
+        }
+
+        // Phase 1, Step 3: Read Capabilities (only on first enable - they don't change)
+        if (isFirstEnable) {
+            sonyCapabilities = readSonyCapabilities(service)
+            Log.info(tag = TAG) { "Sony location service enabled for ${camera.macAddress}" }
+            // Longer delay before first location write - Sony app uses callback flow which
+            // introduces a natural delay. Camera may need time to transition to ready state.
+            delay(500)
+        }
+
+        sonyLocationServiceEnabled = true
+    }
+
+    /**
+     * Reads Sony camera capabilities from DD32 (Time Correction), DD33 (Area Adjustment), and DD21
+     * (Camera Info) characteristics.
+     *
+     * Per Sony decompiled code, the read order is: DD32 -> DD33 -> DD21. These should be read after
+     * locking and enabling the location service.
+     *
+     * @return SonyCapabilities containing the parsed data, or null if reading fails
+     */
+    private suspend fun readSonyCapabilities(
+        service: com.juul.kable.DiscoveredService
+    ): SonyCapabilities? {
+        // Find capability characteristics
+        val configChar =
+            service.characteristics.firstOrNull {
+                it.characteristicUuid == SonyGattSpec.LOCATION_CONFIG_READ_CHARACTERISTIC_UUID
+            }
+        val timeCorrectionChar =
+            service.characteristics.firstOrNull {
+                it.characteristicUuid == SonyGattSpec.TIME_CORRECTION_CHARACTERISTIC_UUID
+            }
+        val areaAdjustmentChar =
+            service.characteristics.firstOrNull {
+                it.characteristicUuid == SonyGattSpec.AREA_ADJUSTMENT_CHARACTERISTIC_UUID
+            }
+
+        var requiresTimezone = true // Default to including timezone
+        var timeCorrection: ByteArray? = null
+        var areaAdjustment: ByteArray? = null
+
+        // Read DD32 (Time Correction) - FIRST per Sony app order
+        if (timeCorrectionChar != null) {
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                timeCorrection =
+                    withTimeout(BLE_WRITE_TIMEOUT_MS) { peripheral.read(timeCorrectionChar) }
+                Log.info(tag = TAG) { "Sony DD32 time correction: ${timeCorrection.toHexString()}" }
+            } catch (e: Exception) {
+                Log.warn(tag = TAG, throwable = e) { "Failed to read DD32 time correction" }
+            }
+        } else {
+            Log.debug(tag = TAG) { "DD32 (Time Correction) characteristic not found" }
+        }
+
+        // Read DD33 (Area Adjustment) - SECOND per Sony app order
+        if (areaAdjustmentChar != null) {
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                areaAdjustment =
+                    withTimeout(BLE_WRITE_TIMEOUT_MS) { peripheral.read(areaAdjustmentChar) }
+                Log.info(tag = TAG) { "Sony DD33 area adjustment: ${areaAdjustment.toHexString()}" }
+            } catch (e: Exception) {
+                Log.warn(tag = TAG, throwable = e) { "Failed to read DD33 area adjustment" }
+            }
+        } else {
+            Log.debug(tag = TAG) { "DD33 (Area Adjustment) characteristic not found" }
+        }
+
+        // Read DD21 (Camera Info / Capability Info) - LAST per Sony app order
+        if (configChar != null) {
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                val configData = withTimeout(BLE_WRITE_TIMEOUT_MS) { peripheral.read(configChar) }
+                requiresTimezone =
+                    (protocol as? dev.sebastiano.camerasync.vendors.sony.SonyProtocol)
+                        ?.parseConfigRequiresTimezone(configData) ?: true
+                Log.info(tag = TAG) {
+                    "Sony DD21 capabilities: requiresTimezone=$requiresTimezone, " +
+                        "raw=${configData.toHexString()}"
+                }
+            } catch (e: Exception) {
+                Log.warn(tag = TAG, throwable = e) { "Failed to read DD21 capabilities" }
+            }
+        } else {
+            Log.debug(tag = TAG) { "DD21 (Camera Info) characteristic not found" }
+        }
+
+        return SonyCapabilities(
+            requiresTimezone = requiresTimezone,
+            timeCorrection = timeCorrection,
+            areaAdjustment = areaAdjustment,
+        )
+    }
+
+    /** Converts a ByteArray to a hex string for logging. */
+    private fun ByteArray.toHexString(): String = joinToString(" ") { "%02X".format(it) }
+
+    /**
+     * Disables the Sony location service by writing to DD31 and DD30.
+     *
+     * Should be called before disconnecting from Sony cameras that use the newer protocol.
+     */
+    private suspend fun disableSonyLocationService() {
+        if (!sonyLocationServiceEnabled || camera.vendor.vendorId != "sony") return
+
+        // Cancel the notification observation job to prevent resource leaks
+        sonyNotificationObservationJob?.cancel()
+        sonyNotificationObservationJob = null
+
+        val service =
+            peripheral.services.value.orEmpty().firstOrNull {
+                it.serviceUuid == gattSpec.locationServiceUuid
+            } ?: return
+
+        val lockChar =
+            service.characteristics.firstOrNull {
+                it.characteristicUuid == SonyGattSpec.LOCATION_LOCK_CHARACTERISTIC_UUID
+            }
+        val enableChar =
+            service.characteristics.firstOrNull {
+                it.characteristicUuid == SonyGattSpec.LOCATION_ENABLE_CHARACTERISTIC_UUID
+            }
+
+        // Only disable if characteristics exist (newer protocol)
+        if (lockChar != null && enableChar != null) {
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                Log.debug(tag = TAG) { "Disabling Sony location service for ${camera.macAddress}" }
+                // Write 0x00 to DD31 first, then DD30
+                // Per spec: 30-second timeout for BLE write operations
+                withTimeout(BLE_WRITE_TIMEOUT_MS) {
+                    peripheral.write(enableChar, byteArrayOf(0x00), WriteType.WithResponse)
+                }
+                withTimeout(BLE_WRITE_TIMEOUT_MS) {
+                    peripheral.write(lockChar, byteArrayOf(0x00), WriteType.WithResponse)
+                }
+                Log.info(tag = TAG) { "Sony location service disabled for ${camera.macAddress}" }
+            } catch (e: Exception) {
+                // BLE writes can fail for various reasons during disconnect; just log and continue
+                Log.warn(tag = TAG, throwable = e) {
+                    "Failed to disable Sony location service for ${camera.macAddress}"
+                }
+            }
+        }
+
+        sonyLocationServiceEnabled = false
     }
 
     @OptIn(ExperimentalApi::class)
     override suspend fun disconnect() {
         Log.info(tag = TAG) { "Disconnecting from ${camera.name}" }
+        // Disable Sony location service before disconnecting (recommended by protocol)
+        disableSonyLocationService()
         peripheral.disconnect()
     }
 
     companion object {
         private const val TAG = "KableCameraConnection"
+
+        /** Timeout for BLE write operations per Sony protocol spec (30 seconds). */
+        private const val BLE_WRITE_TIMEOUT_MS = 30_000L
+
+        /** Maximum number of retries for DD11 location writes per Sony protocol spec. */
+        private const val LOCATION_WRITE_MAX_RETRIES = 3
     }
 
     private fun locationWriteType(): WriteType =
         when (camera.vendor.vendorId) {
-            "sony" -> WriteType.WithoutResponse
+            // Sony cameras: Use WithResponse (per Sony Creators' App which uses
+            // the characteristic's default write type, typically WRITE_TYPE_DEFAULT)
+            "sony" -> WriteType.WithResponse
             else -> WriteType.WithResponse
         }
 }

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/domain/model/Camera.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/domain/model/Camera.kt
@@ -13,4 +13,12 @@ data class Camera(
     val name: String?,
     val macAddress: String,
     val vendor: CameraVendor,
+    /**
+     * BLE protocol version from the advertisement data. For Sony cameras, this determines which
+     * features are available:
+     * - Protocol >= 65: Requires DD30/DD31 unlock sequence for location sync
+     * - Protocol < 65: Uses legacy protocol without DD30/DD31 Null for non-Sony cameras or if not
+     *   available in the advertisement.
+     */
+    val bleProtocolVersion: Int? = null,
 )

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/domain/model/GpsLocation.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/domain/model/GpsLocation.kt
@@ -1,6 +1,13 @@
 package dev.sebastiano.camerasync.domain.model
 
+import java.time.Duration
 import java.time.ZonedDateTime
+
+/**
+ * Maximum age in seconds for a GPS location to be considered fresh. Per Sony protocol spec, only
+ * locations < 10 seconds old should be sent.
+ */
+const val GPS_FRESHNESS_THRESHOLD_SECONDS = 10L
 
 /**
  * Represents a GPS location with coordinates, altitude, and timestamp.
@@ -13,4 +20,40 @@ data class GpsLocation(
     val altitude: Double,
     val accuracy: Float = 0f,
     val timestamp: ZonedDateTime,
-)
+) {
+
+    /**
+     * Checks if this location is fresh enough to be sent to the camera.
+     *
+     * Per Sony protocol specification, location data should only be sent if it is less than
+     * [GPS_FRESHNESS_THRESHOLD_SECONDS] seconds old. Stale data should be discarded.
+     *
+     * @param now The current time to compare against. Defaults to [ZonedDateTime.now].
+     * @return true if the location is fresh (< 10 seconds old), false otherwise.
+     */
+    fun isFresh(now: ZonedDateTime = ZonedDateTime.now()): Boolean {
+        val age = Duration.between(timestamp, now)
+        return age.seconds < GPS_FRESHNESS_THRESHOLD_SECONDS && !age.isNegative
+    }
+
+    /**
+     * Returns the age of this location in seconds.
+     *
+     * @param now The current time to compare against. Defaults to [ZonedDateTime.now].
+     * @return The age in seconds, or a negative value if the timestamp is in the future.
+     */
+    fun ageInSeconds(now: ZonedDateTime = ZonedDateTime.now()): Long =
+        Duration.between(timestamp, now).seconds
+
+    /**
+     * Creates a copy of this location with a fresh timestamp (now).
+     *
+     * This is used for keep-alive messages where we want to re-send the last known coordinates but
+     * with a current timestamp so the camera accepts it as fresh data.
+     *
+     * @param now The timestamp to use. Defaults to [ZonedDateTime.now].
+     * @return A new [GpsLocation] with the same coordinates but the specified timestamp.
+     */
+    fun withFreshTimestamp(now: ZonedDateTime = ZonedDateTime.now()): GpsLocation =
+        copy(timestamp = now)
+}

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/domain/vendor/CameraVendor.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/domain/vendor/CameraVendor.kt
@@ -168,9 +168,13 @@ interface CameraProtocol {
     /**
      * Encodes a GPS location to the vendor's binary format.
      *
+     * @param location The GPS location to encode.
+     * @param includeTimezone Whether to include timezone/DST data in the packet. For Sony cameras,
+     *   this should be determined by reading the DD21 capability characteristic. Default is true
+     *   for backward compatibility.
      * @return Encoded byte array ready to be written to the camera.
      */
-    fun encodeLocation(location: GpsLocation): ByteArray
+    fun encodeLocation(location: GpsLocation, includeTimezone: Boolean = true): ByteArray
 
     /**
      * Decodes a GPS location from the vendor's binary format.

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/pairing/PairingViewModel.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/pairing/PairingViewModel.kt
@@ -19,6 +19,7 @@ import dev.sebastiano.camerasync.domain.repository.CameraRepository
 import dev.sebastiano.camerasync.domain.repository.PairedDevicesRepository
 import dev.sebastiano.camerasync.domain.vendor.CameraVendorRegistry
 import dev.sebastiano.camerasync.feedback.IssueReporter
+import dev.sebastiano.camerasync.vendors.sony.SonyCameraVendor
 import dev.zacsweers.metro.Inject
 import java.io.IOException
 import kotlin.uuid.ExperimentalUuidApi
@@ -166,11 +167,20 @@ class PairingViewModel(
                 manufacturerData = mfrMap,
             ) ?: return null
 
+        // Parse BLE protocol version for Sony cameras
+        val protocolVersion =
+            if (vendor.vendorId == "sony") {
+                SonyCameraVendor.parseProtocolVersion(mfrMap)
+            } else {
+                null
+            }
+
         return Camera(
             identifier = device.address,
             name = name,
             macAddress = device.address,
             vendor = vendor,
+            bleProtocolVersion = protocolVersion,
         )
     }
 

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/scanning/ScanningViewModel.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/scanning/ScanningViewModel.kt
@@ -16,6 +16,7 @@ import dev.sebastiano.camerasync.ble.buildManufacturerDataMap
 import dev.sebastiano.camerasync.domain.model.Camera
 import dev.sebastiano.camerasync.domain.vendor.CameraVendorRegistry
 import dev.sebastiano.camerasync.logging.KhronicleLogEngine
+import dev.sebastiano.camerasync.vendors.sony.SonyCameraVendor
 import kotlin.uuid.ExperimentalUuidApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -125,12 +126,21 @@ internal class ScanningViewModel(private val vendorRegistry: CameraVendorRegistr
             return null
         }
 
+        // Parse BLE protocol version for Sony cameras
+        val protocolVersion =
+            if (vendor.vendorId == "sony") {
+                SonyCameraVendor.parseProtocolVersion(mfrData)
+            } else {
+                null
+            }
+
         Log.info(tag = TAG) { "Discovered ${vendor.vendorName} camera: ${peripheralName ?: name}" }
         return Camera(
             identifier = identifier,
             name = peripheralName ?: name,
             macAddress = identifier,
             vendor = vendor,
+            bleProtocolVersion = protocolVersion,
         )
     }
 }

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/vendors/ricoh/RicohProtocol.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/vendors/ricoh/RicohProtocol.kt
@@ -82,7 +82,8 @@ object RicohProtocol : CameraProtocol {
      * - Byte 30: Second (0-59)
      * - Byte 31: Padding (0)
      */
-    override fun encodeLocation(location: GpsLocation): ByteArray =
+    @Suppress("UNUSED_PARAMETER") // Ricoh cameras don't use timezone parameter
+    override fun encodeLocation(location: GpsLocation, includeTimezone: Boolean): ByteArray =
         Buffer()
             .writeLong(location.latitude.toRawBits())
             .writeLong(location.longitude.toRawBits())

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/vendors/sony/SonyGattSpec.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/vendors/sony/SonyGattSpec.kt
@@ -7,9 +7,11 @@ import kotlin.uuid.Uuid
 /**
  * GATT specification for Sony Alpha cameras.
  *
- * Based on the DI Remote Control protocol documentation. See:
- * https://gethypoxic.com/blogs/technical/sony-camera-ble-control-protocol-di-remote-control See:
- * https://github.com/whc2001/ILCE7M3ExternalGps/blob/main/PROTOCOL_EN.md
+ * Based on reverse-engineered protocol from Sony Creators' App. See docs/sony/DATETIME_GPS_SYNC.md
+ * for full protocol documentation.
+ *
+ * Note: While Sony services use a custom UUID format (8000xxxx-xxxx-FFFF-FFFF-FFFFFFFFFFFF), the
+ * characteristics within those services use the standard Bluetooth SIG base UUID format.
  */
 @OptIn(ExperimentalUuidApi::class)
 object SonyGattSpec : CameraGattSpec {
@@ -17,43 +19,61 @@ object SonyGattSpec : CameraGattSpec {
     /** Remote Control Service UUID - used for scanning and filtering Sony camera advertisements. */
     val REMOTE_CONTROL_SERVICE_UUID: Uuid = Uuid.parse("8000FF00-FF00-FFFF-FFFF-FFFFFFFFFFFF")
 
-    /** Location Service UUID - used for GPS and time synchronization. */
+    // ==================== Location Service (DD) ====================
+    /** Location Service UUID - used for GPS synchronization. */
     val LOCATION_SERVICE_UUID: Uuid = Uuid.parse("8000DD00-DD00-FFFF-FFFF-FFFFFFFFFFFF")
 
-    /** Location Status Notify Characteristic (DD01) - subscribe for status notifications. */
+    /**
+     * Location Status Notify Characteristic (DD01) - subscribe for transfer status notifications.
+     */
     val LOCATION_STATUS_NOTIFY_CHARACTERISTIC_UUID: Uuid =
         Uuid.parse("0000DD01-0000-1000-8000-00805f9b34fb")
 
-    /** Location Data Write Characteristic (DD11) - write location and time data here. */
+    /** Location Data Write Characteristic (DD11) - write GPS location and timestamp data. */
     val LOCATION_DATA_WRITE_CHARACTERISTIC_UUID: Uuid =
         Uuid.parse("0000DD11-0000-1000-8000-00805f9b34fb")
 
     /**
-     * Configuration Read Characteristic (DD21) - read to check if timezone/DST data is required.
+     * Capability Info Characteristic (DD21) - read camera capabilities and timezone requirements.
      */
     val LOCATION_CONFIG_READ_CHARACTERISTIC_UUID: Uuid =
         Uuid.parse("0000DD21-0000-1000-8000-00805f9b34fb")
 
-    /** Lock Location Endpoint (DD30) - firmware 3.02+ only. */
+    /**
+     * Lock Control Characteristic (DD30) - locks/unlocks location transfer session (1=Lock,
+     * 0=Unlock).
+     */
     val LOCATION_LOCK_CHARACTERISTIC_UUID: Uuid = Uuid.parse("0000DD30-0000-1000-8000-00805f9b34fb")
 
-    /** Enable Location Update (DD31) - firmware 3.02+ only. */
+    /**
+     * Transfer Enable Characteristic (DD31) - enables/disables location transfer (1=Enable,
+     * 0=Disable).
+     */
     val LOCATION_ENABLE_CHARACTERISTIC_UUID: Uuid =
         Uuid.parse("0000DD31-0000-1000-8000-00805f9b34fb")
 
+    /** Time Correction Characteristic (DD32) - read for time correction data. */
+    val TIME_CORRECTION_CHARACTERISTIC_UUID: Uuid =
+        Uuid.parse("0000DD32-0000-1000-8000-00805f9b34fb")
+
+    /** Area Adjustment Characteristic (DD33) - read for area adjustment data. */
+    val AREA_ADJUSTMENT_CHARACTERISTIC_UUID: Uuid =
+        Uuid.parse("0000DD33-0000-1000-8000-00805f9b34fb")
+
+    // ==================== Pairing Service (EE) ====================
     /** Pairing Service UUID. */
     val PAIRING_SERVICE_UUID: Uuid = Uuid.parse("8000EE00-EE00-FFFF-FFFF-FFFFFFFFFFFF")
 
-    /**
-     * Pairing Characteristic (EE01) - write pairing initialization data.
-     *
-     * Note: While Sony services use a custom UUID format (8000xxxx-xxxx-FFFF-FFFF-FFFFFFFFFFFF),
-     * the characteristics within those services use the standard Bluetooth SIG base UUID format.
-     */
+    /** Pairing Characteristic (EE01) - write pairing initialization data. */
     val PAIRING_CHARACTERISTIC_UUID: Uuid = Uuid.parse("0000EE01-0000-1000-8000-00805f9b34fb")
 
-    /** Camera Control Service UUID - used for firmware version and model name. */
+    // ==================== Camera Control Service (CC) ====================
+    /** Camera Control Service UUID - used for date/time, firmware version, and model name. */
     val CAMERA_CONTROL_SERVICE_UUID: Uuid = Uuid.parse("8000CC00-CC00-FFFF-FFFF-FFFFFFFFFFFF")
+
+    /** Completion Status Characteristic (CC09) - read to check if time setting is done. */
+    val TIME_COMPLETION_STATUS_CHARACTERISTIC_UUID: Uuid =
+        Uuid.parse("0000CC09-0000-1000-8000-00805f9b34fb")
 
     /** Firmware version characteristic (CC0A) - US-ASCII string. */
     val FIRMWARE_VERSION_CHARACTERISTIC_UUID: Uuid =
@@ -62,6 +82,21 @@ object SonyGattSpec : CameraGattSpec {
     /** Model name characteristic (CC0B) - US-ASCII string. */
     val MODEL_NAME_CHARACTERISTIC_UUID: Uuid = Uuid.parse("0000CC0B-0000-1000-8000-00805f9b34fb")
 
+    /** Notification Characteristic (CC0E) - subscribe for date/time setting confirmation. */
+    val DATETIME_NOTIFY_CHARACTERISTIC_UUID: Uuid =
+        Uuid.parse("0000CC0E-0000-1000-8000-00805f9b34fb")
+
+    /** Date Format Setting Characteristic (CC12) - sets date display format (YMD/DMY/etc). */
+    val DATE_FORMAT_CHARACTERISTIC_UUID: Uuid = Uuid.parse("0000CC12-0000-1000-8000-00805f9b34fb")
+
+    /**
+     * Time Area Setting Characteristic (CC13) - sets current time and timezone. This is the proper
+     * characteristic for date/time synchronization (13-byte payload).
+     */
+    val TIME_AREA_SETTING_CHARACTERISTIC_UUID: Uuid =
+        Uuid.parse("0000CC13-0000-1000-8000-00805f9b34fb")
+
+    // ==================== Overrides ====================
     override val scanFilterServiceUuids: List<Uuid> =
         listOf(REMOTE_CONTROL_SERVICE_UUID, PAIRING_SERVICE_UUID)
 
@@ -76,9 +111,13 @@ object SonyGattSpec : CameraGattSpec {
     override val deviceNameServiceUuid: Uuid? = null
     override val deviceNameCharacteristicUuid: Uuid? = null
 
-    /** Sony uses the Location Service for date/time sync (combined with location). */
-    override val dateTimeServiceUuid: Uuid = LOCATION_SERVICE_UUID
-    override val dateTimeCharacteristicUuid: Uuid = LOCATION_DATA_WRITE_CHARACTERISTIC_UUID
+    /**
+     * Sony uses the Camera Control Service for dedicated date/time sync via CC13. Note: Location
+     * packets (DD11) also contain timestamp data, but CC13 is the proper characteristic for setting
+     * just date/time without location.
+     */
+    override val dateTimeServiceUuid: Uuid = CAMERA_CONTROL_SERVICE_UUID
+    override val dateTimeCharacteristicUuid: Uuid = TIME_AREA_SETTING_CHARACTERISTIC_UUID
 
     /** Sony doesn't have a separate geo-tagging toggle characteristic. */
     override val geoTaggingCharacteristicUuid: Uuid? = null

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/vendors/sony/SonyProtocol.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/vendors/sony/SonyProtocol.kt
@@ -11,25 +11,40 @@ import java.time.format.DateTimeFormatter
 /**
  * Protocol implementation for Sony Alpha cameras.
  *
- * Based on the protocol documentation at:
- * https://github.com/whc2001/ILCE7M3ExternalGps/blob/main/PROTOCOL_EN.md
+ * Based on reverse-engineered protocol from Sony Creators' App. See docs/sony/DATETIME_GPS_SYNC.md
+ * for full protocol documentation.
  *
- * Packet structure (Big Endian):
- * - Bytes 0-1: Payload length (excludes these 2 bytes)
+ * IMPORTANT: All multi-byte integers are Big-Endian (Network Byte Order).
+ *
+ * Location packet structure (DD11):
+ * - Bytes 0-1: Payload length (Big-Endian, excludes these 2 bytes)
  * - Bytes 2-4: Fixed header (0x08 0x02 0xFC)
  * - Byte 5: Timezone/DST flag (0x03 = include, 0x00 = omit)
- * - Bytes 6-10: Fixed data (0x00 0x00 0x10 0x10 0x10)
- * - Bytes 11-14: Latitude × 10,000,000 (signed int32)
- * - Bytes 15-18: Longitude × 10,000,000 (signed int32)
- * - Bytes 19-20: UTC Year
+ * - Bytes 6-7: Padding (zeros)
+ * - Bytes 8-10: Fixed padding (0x10)
+ * - Bytes 11-14: Latitude × 10,000,000 (signed int32, Big-Endian)
+ * - Bytes 15-18: Longitude × 10,000,000 (signed int32, Big-Endian)
+ * - Bytes 19-20: UTC Year (Big-Endian)
  * - Byte 21: UTC Month (1-12)
  * - Byte 22: UTC Day (1-31)
  * - Byte 23: UTC Hour (0-23)
  * - Byte 24: UTC Minute (0-59)
  * - Byte 25: UTC Second (0-59)
  * - Bytes 26-90: Padding (zeros)
- * - Bytes 91-92: Timezone offset in minutes (only if flag is 0x03)
- * - Bytes 93-94: DST offset in minutes (only if flag is 0x03)
+ * - Bytes 91-92: Timezone offset in minutes (Big-Endian, only if flag is 0x03)
+ * - Bytes 93-94: DST offset in minutes (Big-Endian, only if flag is 0x03)
+ *
+ * Time Area packet structure (CC13):
+ * - Bytes 0-2: Header (0x0C 0x00 0x00)
+ * - Bytes 3-4: Year (uint16, Big-Endian)
+ * - Byte 5: Month (1-12)
+ * - Byte 6: Day (1-31)
+ * - Byte 7: Hour (0-23)
+ * - Byte 8: Minute (0-59)
+ * - Byte 9: Second (0-59)
+ * - Byte 10: DST Flag (0=Standard, 1=DST)
+ * - Byte 11: Timezone Offset Hours (int8, signed)
+ * - Byte 12: Timezone Offset Minutes (uint8)
  */
 object SonyProtocol : CameraProtocol {
 
@@ -42,8 +57,12 @@ object SonyProtocol : CameraProtocol {
     /** Fixed header bytes. */
     private val HEADER = byteArrayOf(0x08, 0x02, 0xFC.toByte())
 
-    /** Fixed data after the timezone flag. */
-    private val FIXED_DATA = byteArrayOf(0x00, 0x00, 0x10, 0x10, 0x10)
+    /**
+     * Padding after the timezone flag (5 bytes).
+     * - Bytes 6-7: 0x00 (padding)
+     * - Bytes 8-10: 0x10 (fixed padding, decimal 16)
+     */
+    private val PADDING_AFTER_FLAG = byteArrayOf(0x00, 0x00, 0x10, 0x10, 0x10)
 
     /** Timezone/DST flag: include timezone data. */
     private const val TZ_FLAG_INCLUDE: Byte = 0x03
@@ -54,47 +73,116 @@ object SonyProtocol : CameraProtocol {
     /** Coordinate scaling factor. */
     private const val COORDINATE_SCALE = 10_000_000.0
 
+    /** Time Area Setting (CC13) packet size. */
+    private const val TIME_AREA_PACKET_SIZE = 13
+
+    /** Time Area Setting (CC13) header. */
+    private val TIME_AREA_HEADER = byteArrayOf(0x0C, 0x00, 0x00)
+
     /**
-     * Encodes date/time for Sony cameras.
+     * Encodes date/time for Sony cameras using the Time Area Setting (CC13) characteristic.
      *
-     * Note: Sony combines location and time in the same packet. This method sends a packet with
-     * zero coordinates but valid time data.
+     * Payload structure (13 bytes):
+     * - Bytes 0-2: Header (0x0C 0x00 0x00)
+     * - Bytes 3-4: Year (uint16, Big-Endian)
+     * - Byte 5: Month (1-12)
+     * - Byte 6: Day (1-31)
+     * - Byte 7: Hour (0-23)
+     * - Byte 8: Minute (0-59)
+     * - Byte 9: Second (0-59)
+     * - Byte 10: DST Flag (0=Standard, 1=DST)
+     * - Byte 11: Timezone Offset Hours (int8, signed)
+     * - Byte 12: Timezone Offset Minutes (uint8)
      */
     override fun encodeDateTime(dateTime: ZonedDateTime): ByteArray {
-        return encodeLocationPacket(
-            latitude = 0.0,
-            longitude = 0.0,
-            dateTime = dateTime,
-            includeTimezone = true,
-        )
+        val buffer = ByteBuffer.allocate(TIME_AREA_PACKET_SIZE).order(ByteOrder.BIG_ENDIAN)
+
+        // Header (3 bytes)
+        buffer.put(TIME_AREA_HEADER)
+
+        // Year (2 bytes, Big-Endian)
+        buffer.putShort(dateTime.year.toShort())
+
+        // Month, Day, Hour, Minute, Second (1 byte each)
+        buffer.put(dateTime.monthValue.toByte())
+        buffer.put(dateTime.dayOfMonth.toByte())
+        buffer.put(dateTime.hour.toByte())
+        buffer.put(dateTime.minute.toByte())
+        buffer.put(dateTime.second.toByte())
+
+        // DST Flag - check if the zone is in DST
+        val isDst = dateTime.zone.rules.isDaylightSavings(dateTime.toInstant())
+        buffer.put(if (isDst) 0x01.toByte() else 0x00.toByte())
+
+        // Timezone offset in split format:
+        // Byte 11: Signed hours (int8)
+        // Byte 12: Minutes (uint8)
+        val totalOffsetSeconds = dateTime.offset.totalSeconds
+        val offsetHours = totalOffsetSeconds / 3600
+        val offsetMinutes = kotlin.math.abs((totalOffsetSeconds % 3600) / 60)
+        buffer.put(offsetHours.toByte())
+        buffer.put(offsetMinutes.toByte())
+
+        return buffer.array()
     }
 
     override fun decodeDateTime(bytes: ByteArray): String {
-        if (bytes.size < PACKET_SIZE_WITHOUT_TZ) {
-            return "Invalid data: expected at least $PACKET_SIZE_WITHOUT_TZ bytes, got ${bytes.size}"
+        return when {
+            // CC13 Time Area format (13 bytes)
+            bytes.size == TIME_AREA_PACKET_SIZE -> decodeTimeAreaPacket(bytes)
+            // DD11 Location packet format (91 or 95 bytes)
+            bytes.size >= PACKET_SIZE_WITHOUT_TZ -> decodeLocationDateTime(bytes)
+            else ->
+                "Invalid data: expected $TIME_AREA_PACKET_SIZE or $PACKET_SIZE_WITHOUT_TZ+ bytes, got ${bytes.size}"
         }
+    }
 
+    /** Decodes a Time Area Setting (CC13) packet. */
+    private fun decodeTimeAreaPacket(bytes: ByteArray): String {
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN)
+
+        // Skip header (3 bytes)
+        buffer.position(3)
+        val year = buffer.short.toInt() and 0xFFFF
+        val month = buffer.get().toInt() and 0xFF
+        val day = buffer.get().toInt() and 0xFF
+        val hour = buffer.get().toInt() and 0xFF
+        val minute = buffer.get().toInt() and 0xFF
+        val second = buffer.get().toInt() and 0xFF
+        val dstFlag = buffer.get().toInt() and 0xFF
+        val tzHours = buffer.get().toInt() // signed
+        val tzMinutes = buffer.get().toInt() and 0xFF
+
+        val offsetSeconds = tzHours * 3600 + (if (tzHours >= 0) tzMinutes else -tzMinutes) * 60
+        val offset = ZoneOffset.ofTotalSeconds(offsetSeconds)
+        val dateTime = ZonedDateTime.of(year, month, day, hour, minute, second, 0, offset)
+        val dstStr = if (dstFlag == 1) " (DST)" else ""
+        return dateTime.format(DateTimeFormatter.ISO_ZONED_DATE_TIME) + dstStr
+    }
+
+    /** Decodes date/time from a DD11 location packet. */
+    private fun decodeLocationDateTime(bytes: ByteArray): String {
         val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN)
 
         // Skip to date/time fields (offset 19)
         buffer.position(19)
-        val year = buffer.short.toInt()
-        val month = buffer.get().toInt()
-        val day = buffer.get().toInt()
-        val hour = buffer.get().toInt()
-        val minute = buffer.get().toInt()
-        val second = buffer.get().toInt()
+        val year = buffer.short.toInt() and 0xFFFF
+        val month = buffer.get().toInt() and 0xFF
+        val day = buffer.get().toInt() and 0xFF
+        val hour = buffer.get().toInt() and 0xFF
+        val minute = buffer.get().toInt() and 0xFF
+        val second = buffer.get().toInt() and 0xFF
 
         val dateTime = ZonedDateTime.of(year, month, day, hour, minute, second, 0, ZoneOffset.UTC)
         return dateTime.format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
     }
 
-    override fun encodeLocation(location: GpsLocation): ByteArray {
+    override fun encodeLocation(location: GpsLocation, includeTimezone: Boolean): ByteArray {
         return encodeLocationPacket(
             latitude = location.latitude,
             longitude = location.longitude,
             dateTime = location.timestamp,
-            includeTimezone = true,
+            includeTimezone = includeTimezone,
         )
     }
 
@@ -112,12 +200,12 @@ object SonyProtocol : CameraProtocol {
         val latitude = latRaw / COORDINATE_SCALE
         val longitude = lonRaw / COORDINATE_SCALE
 
-        val year = buffer.short.toInt()
-        val month = buffer.get().toInt()
-        val day = buffer.get().toInt()
-        val hour = buffer.get().toInt()
-        val minute = buffer.get().toInt()
-        val second = buffer.get().toInt()
+        val year = buffer.short.toInt() and 0xFFFF
+        val month = buffer.get().toInt() and 0xFF
+        val day = buffer.get().toInt() and 0xFF
+        val hour = buffer.get().toInt() and 0xFF
+        val minute = buffer.get().toInt() and 0xFF
+        val second = buffer.get().toInt() and 0xFF
 
         val dateTimeStr =
             "%04d-%02d-%02d %02d:%02d:%02d UTC".format(year, month, day, hour, minute, second)
@@ -135,6 +223,8 @@ object SonyProtocol : CameraProtocol {
     /**
      * Encodes a complete location packet for Sony cameras.
      *
+     * IMPORTANT: All multi-byte integers are Big-Endian (Network Byte Order).
+     *
      * @param latitude Latitude in degrees (-90 to 90)
      * @param longitude Longitude in degrees (-180 to 180)
      * @param dateTime The timestamp to encode
@@ -146,13 +236,23 @@ object SonyProtocol : CameraProtocol {
         dateTime: ZonedDateTime,
         includeTimezone: Boolean,
     ): ByteArray {
+        // DD11 uses UTC time (unlike CC13 which uses local time)
+        // Per Sony decompiled code: Calendar.getInstance(TimeZone.getTimeZone("UTC"))
         val utcDateTime = dateTime.withZoneSameInstant(ZoneOffset.UTC)
+
+        // Get system timezone for the timezone offset fields
+        val systemZone = java.time.ZoneId.systemDefault()
+        val zoneRules = systemZone.rules
+        val instant = dateTime.toInstant()
+        val standardOffset = zoneRules.getStandardOffset(instant)
+        val actualOffset = zoneRules.getOffset(instant)
+
         val packetSize = if (includeTimezone) PACKET_SIZE_WITH_TZ else PACKET_SIZE_WITHOUT_TZ
         val payloadSize = packetSize - 2 // Exclude the 2-byte length field
 
         val buffer = ByteBuffer.allocate(packetSize).order(ByteOrder.BIG_ENDIAN)
 
-        // Payload length (2 bytes)
+        // Payload length (2 bytes, Big-Endian)
         buffer.putShort(payloadSize.toShort())
 
         // Fixed header (3 bytes)
@@ -161,16 +261,16 @@ object SonyProtocol : CameraProtocol {
         // Timezone/DST flag (1 byte)
         buffer.put(if (includeTimezone) TZ_FLAG_INCLUDE else TZ_FLAG_OMIT)
 
-        // Fixed data (5 bytes)
-        buffer.put(FIXED_DATA)
+        // Padding (5 bytes of zeros)
+        buffer.put(PADDING_AFTER_FLAG)
 
-        // Latitude × 10,000,000 (4 bytes)
+        // Latitude × 10,000,000 (4 bytes, Big-Endian)
         buffer.putInt((latitude * COORDINATE_SCALE).toInt())
 
-        // Longitude × 10,000,000 (4 bytes)
+        // Longitude × 10,000,000 (4 bytes, Big-Endian)
         buffer.putInt((longitude * COORDINATE_SCALE).toInt())
 
-        // UTC Year (2 bytes)
+        // UTC Year (2 bytes, Big-Endian)
         buffer.putShort(utcDateTime.year.toShort())
 
         // UTC Month, Day, Hour, Minute, Second (1 byte each)
@@ -183,30 +283,40 @@ object SonyProtocol : CameraProtocol {
         // Padding (65 bytes of zeros) - bytes 26-90
         repeat(65) { buffer.put(0) }
 
-        // Timezone and DST offsets (if included)
+        // Timezone and DST offsets (if included, Big-Endian)
         if (includeTimezone) {
-            val offsetSeconds = dateTime.offset.totalSeconds
-            val offsetMinutes = offsetSeconds / 60
+            // Calculate DST offset (difference between actual and standard offset)
+            val dstOffsetSeconds = actualOffset.totalSeconds - standardOffset.totalSeconds
+            val dstOffsetMinutes = dstOffsetSeconds / 60
 
-            // For simplicity, we put the full offset as timezone and 0 for DST
-            // A more sophisticated implementation would separate DST from standard offset
-            buffer.putShort(offsetMinutes.toShort())
-            buffer.putShort(0) // DST offset - would need calendar data to compute accurately
+            // Standard timezone offset in minutes (without DST)
+            val tzOffsetMinutes = standardOffset.totalSeconds / 60
+
+            // Timezone offset in total minutes (int16, Big-Endian)
+            buffer.putShort(tzOffsetMinutes.toShort())
+            // DST offset in minutes (int16, Big-Endian)
+            buffer.putShort(dstOffsetMinutes.toShort())
         }
 
         return buffer.array()
     }
 
     /**
-     * Parses a configuration response from DD21 to determine if timezone data is required.
+     * Parses a configuration response from DD21 to determine if timezone data is supported.
      *
-     * Response format: 6 bytes, byte 4 bit 2 indicates timezone requirement.
+     * Detection Logic (per Sony protocol documentation):
+     * 1. Read characteristic 0000DD21 (Camera Info)
+     * 2. Check the 5th byte (index 4) of the returned array
+     * 3. Perform a bitwise AND with 0x02 (Bit 1)
+     *     - If (Byte[4] & 0x02) == 0x02: Timezone is supported. Use 95-byte payload.
+     *     - If (Byte[4] & 0x02) == 0x00: Timezone is not supported. Use 91-byte payload.
      *
-     * @return true if timezone/DST data should be included in location packets
+     * @return true if timezone/DST data should be included in location packets (95-byte payload),
+     *   false if timezone is not supported (91-byte payload)
      */
     fun parseConfigRequiresTimezone(bytes: ByteArray): Boolean {
         if (bytes.size < 5) return false
-        return (bytes[4].toInt() and 0x04) != 0
+        return (bytes[4].toInt() and 0x02) != 0
     }
 
     /**

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/widget/SyncWidget.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/widget/SyncWidget.kt
@@ -72,8 +72,6 @@ internal class SyncWidget : GlanceAppWidget() {
 
     override suspend fun providePreview(context: Context, widgetCategory: Int) {
         provideContent {
-            val size = DpSize(LocalSize.current.width, LocalSize.current.height)
-            Log.info("!!!!!") { "Updating lockscreen widget preview... size: $size dp" }
             GlanceTheme {
                 WidgetContent(isSyncEnabled = true, connectedCount = 1, isSearching = false)
             }
@@ -91,7 +89,6 @@ private fun WidgetContent(isSyncEnabled: Boolean, connectedCount: Int, isSearchi
             val rowHeight = if (showSecondRow) (height - 8.dp) / 2 else height
             val unitWidth = min(rowHeight, (width - 8.dp) / 3)
             val cornerRadius = max(unitWidth, rowHeight)
-            Log.info("!!!!!") { "New size: $width x $height dp" }
 
             FirstRow(unitWidth, cornerRadius, isSyncEnabled, connectedCount)
 

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/domain/model/GpsLocationTest.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/domain/model/GpsLocationTest.kt
@@ -1,0 +1,210 @@
+package dev.sebastiano.camerasync.domain.model
+
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [GpsLocation] freshness checking.
+ *
+ * Per Sony protocol spec (docs/sony/DATETIME_GPS_SYNC.md):
+ * - Only send location data if it is fresh (< 10 seconds old)
+ * - Stale data should be discarded
+ */
+class GpsLocationTest {
+
+    private val baseTime = ZonedDateTime.of(2024, 12, 25, 12, 0, 0, 0, ZoneOffset.UTC)
+
+    private fun createLocation(timestamp: ZonedDateTime) =
+        GpsLocation(
+            latitude = 37.7749,
+            longitude = -122.4194,
+            altitude = 10.0,
+            timestamp = timestamp,
+        )
+
+    // ==================== isFresh() Tests ====================
+
+    @Test
+    fun `isFresh returns true for location 0 seconds old`() {
+        val location = createLocation(baseTime)
+        assertTrue(location.isFresh(now = baseTime))
+    }
+
+    @Test
+    fun `isFresh returns true for location 5 seconds old`() {
+        val locationTime = baseTime.minusSeconds(5)
+        val location = createLocation(locationTime)
+        assertTrue(location.isFresh(now = baseTime))
+    }
+
+    @Test
+    fun `isFresh returns true for location 9 seconds old`() {
+        val locationTime = baseTime.minusSeconds(9)
+        val location = createLocation(locationTime)
+        assertTrue(location.isFresh(now = baseTime))
+    }
+
+    @Test
+    fun `isFresh returns false for location exactly 10 seconds old`() {
+        val locationTime = baseTime.minusSeconds(10)
+        val location = createLocation(locationTime)
+        assertFalse(location.isFresh(now = baseTime))
+    }
+
+    @Test
+    fun `isFresh returns false for location 11 seconds old`() {
+        val locationTime = baseTime.minusSeconds(11)
+        val location = createLocation(locationTime)
+        assertFalse(location.isFresh(now = baseTime))
+    }
+
+    @Test
+    fun `isFresh returns false for location 60 seconds old`() {
+        val locationTime = baseTime.minusSeconds(60)
+        val location = createLocation(locationTime)
+        assertFalse(location.isFresh(now = baseTime))
+    }
+
+    @Test
+    fun `isFresh returns false for location with future timestamp`() {
+        val locationTime = baseTime.plusSeconds(5) // Future timestamp
+        val location = createLocation(locationTime)
+        assertFalse(location.isFresh(now = baseTime))
+    }
+
+    @Test
+    fun `isFresh handles different timezones correctly`() {
+        // Location at 12:00 UTC
+        val locationTime = ZonedDateTime.of(2024, 12, 25, 12, 0, 0, 0, ZoneOffset.UTC)
+        val location = createLocation(locationTime)
+
+        // Now is 12:00:05 in UTC+8 (which is 04:00:05 UTC - 8 hours behind)
+        // This would be 7:59:55 behind the location time, so NOT fresh
+        val nowInDifferentZone = ZonedDateTime.of(2024, 12, 25, 12, 0, 5, 0, ZoneOffset.ofHours(8))
+
+        // The location is from "the future" relative to the now time, so not fresh
+        assertFalse(location.isFresh(now = nowInDifferentZone))
+    }
+
+    @Test
+    fun `isFresh uses current time by default`() {
+        // Create a location with current time
+        val location = createLocation(ZonedDateTime.now())
+        assertTrue(location.isFresh())
+    }
+
+    // ==================== ageInSeconds() Tests ====================
+
+    @Test
+    fun `ageInSeconds returns 0 for same timestamp`() {
+        val location = createLocation(baseTime)
+        assertEquals(0L, location.ageInSeconds(now = baseTime))
+    }
+
+    @Test
+    fun `ageInSeconds returns positive value for past timestamp`() {
+        val locationTime = baseTime.minusSeconds(30)
+        val location = createLocation(locationTime)
+        assertEquals(30L, location.ageInSeconds(now = baseTime))
+    }
+
+    @Test
+    fun `ageInSeconds returns negative value for future timestamp`() {
+        val locationTime = baseTime.plusSeconds(15)
+        val location = createLocation(locationTime)
+        assertEquals(-15L, location.ageInSeconds(now = baseTime))
+    }
+
+    @Test
+    fun `ageInSeconds handles large time differences`() {
+        val locationTime = baseTime.minusHours(1)
+        val location = createLocation(locationTime)
+        assertEquals(3600L, location.ageInSeconds(now = baseTime))
+    }
+
+    // ==================== GPS_FRESHNESS_THRESHOLD_SECONDS Constant Test ====================
+
+    @Test
+    fun `GPS_FRESHNESS_THRESHOLD_SECONDS is 10 as per spec`() {
+        assertEquals(10L, GPS_FRESHNESS_THRESHOLD_SECONDS)
+    }
+
+    // ==================== Data Class Tests ====================
+
+    @Test
+    fun `GpsLocation stores all properties correctly`() {
+        val timestamp = ZonedDateTime.now()
+        val location =
+            GpsLocation(
+                latitude = 51.5074,
+                longitude = -0.1278,
+                altitude = 100.5,
+                accuracy = 5.0f,
+                timestamp = timestamp,
+            )
+
+        assertEquals(51.5074, location.latitude, 0.0001)
+        assertEquals(-0.1278, location.longitude, 0.0001)
+        assertEquals(100.5, location.altitude, 0.0001)
+        assertEquals(5.0f, location.accuracy, 0.001f)
+        assertEquals(timestamp, location.timestamp)
+    }
+
+    @Test
+    fun `GpsLocation default accuracy is 0`() {
+        val location = createLocation(baseTime)
+        assertEquals(0f, location.accuracy, 0.001f)
+    }
+
+    // ==================== withFreshTimestamp() Tests ====================
+
+    @Test
+    fun `withFreshTimestamp creates copy with new timestamp`() {
+        val oldTime = baseTime.minusMinutes(5)
+        val location = createLocation(oldTime)
+        val newTime = baseTime
+
+        val freshLocation = location.withFreshTimestamp(newTime)
+
+        assertEquals(newTime, freshLocation.timestamp)
+        assertEquals(location.latitude, freshLocation.latitude, 0.0001)
+        assertEquals(location.longitude, freshLocation.longitude, 0.0001)
+        assertEquals(location.altitude, freshLocation.altitude, 0.0001)
+        assertEquals(location.accuracy, freshLocation.accuracy, 0.001f)
+    }
+
+    @Test
+    fun `withFreshTimestamp makes stale location fresh`() {
+        val staleTime = baseTime.minusSeconds(30)
+        val staleLocation = createLocation(staleTime)
+
+        assertFalse(staleLocation.isFresh(now = baseTime))
+
+        val freshLocation = staleLocation.withFreshTimestamp(baseTime)
+
+        assertTrue(freshLocation.isFresh(now = baseTime))
+    }
+
+    @Test
+    fun `withFreshTimestamp preserves coordinates exactly`() {
+        val location =
+            GpsLocation(
+                latitude = 37.7749123456,
+                longitude = -122.4194987654,
+                altitude = 123.456,
+                accuracy = 2.5f,
+                timestamp = baseTime.minusHours(1),
+            )
+
+        val freshLocation = location.withFreshTimestamp(baseTime)
+
+        assertEquals(37.7749123456, freshLocation.latitude, 0.0)
+        assertEquals(-122.4194987654, freshLocation.longitude, 0.0)
+        assertEquals(123.456, freshLocation.altitude, 0.0)
+        assertEquals(2.5f, freshLocation.accuracy, 0.0f)
+    }
+}

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/fakes/FakeVendorRegistry.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/fakes/FakeVendorRegistry.kt
@@ -105,7 +105,8 @@ object FakeProtocol : CameraProtocol {
 
     override fun decodeDateTime(bytes: ByteArray): String = "decoded-datetime"
 
-    override fun encodeLocation(location: GpsLocation): ByteArray = byteArrayOf()
+    override fun encodeLocation(location: GpsLocation, includeTimezone: Boolean): ByteArray =
+        byteArrayOf()
 
     override fun decodeLocation(bytes: ByteArray): String = "decoded-location"
 

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/vendors/sony/SonyGattSpecTest.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/vendors/sony/SonyGattSpecTest.kt
@@ -3,11 +3,25 @@ package dev.sebastiano.camerasync.vendors.sony
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
+/**
+ * Comprehensive tests for [SonyGattSpec].
+ *
+ * These tests verify:
+ * - All characteristic UUIDs match Sony's protocol documentation
+ * - Service and characteristic relationships are correct
+ * - Date/Time uses CC13 (not DD11) per the protocol spec
+ * - Location uses DD11 for GPS data
+ *
+ * See docs/sony/DATETIME_GPS_SYNC.md for protocol documentation.
+ */
 @OptIn(ExperimentalUuidApi::class)
 class SonyGattSpecTest {
+
+    // ==================== Service UUID Tests ====================
 
     @Test
     fun `remote control service UUID matches documentation`() {
@@ -26,46 +40,6 @@ class SonyGattSpecTest {
     }
 
     @Test
-    fun `location status notify characteristic UUID matches documentation`() {
-        assertEquals(
-            Uuid.parse("0000DD01-0000-1000-8000-00805f9b34fb"),
-            SonyGattSpec.LOCATION_STATUS_NOTIFY_CHARACTERISTIC_UUID,
-        )
-    }
-
-    @Test
-    fun `location data write characteristic UUID matches documentation`() {
-        assertEquals(
-            Uuid.parse("0000DD11-0000-1000-8000-00805f9b34fb"),
-            SonyGattSpec.LOCATION_DATA_WRITE_CHARACTERISTIC_UUID,
-        )
-    }
-
-    @Test
-    fun `location config read characteristic UUID matches documentation`() {
-        assertEquals(
-            Uuid.parse("0000DD21-0000-1000-8000-00805f9b34fb"),
-            SonyGattSpec.LOCATION_CONFIG_READ_CHARACTERISTIC_UUID,
-        )
-    }
-
-    @Test
-    fun `location lock characteristic UUID matches documentation`() {
-        assertEquals(
-            Uuid.parse("0000DD30-0000-1000-8000-00805f9b34fb"),
-            SonyGattSpec.LOCATION_LOCK_CHARACTERISTIC_UUID,
-        )
-    }
-
-    @Test
-    fun `location enable characteristic UUID matches documentation`() {
-        assertEquals(
-            Uuid.parse("0000DD31-0000-1000-8000-00805f9b34fb"),
-            SonyGattSpec.LOCATION_ENABLE_CHARACTERISTIC_UUID,
-        )
-    }
-
-    @Test
     fun `pairing service UUID matches documentation`() {
         assertEquals(
             Uuid.parse("8000EE00-EE00-FFFF-FFFF-FFFFFFFFFFFF"),
@@ -74,7 +48,75 @@ class SonyGattSpecTest {
     }
 
     @Test
-    fun `pairing characteristic UUID uses standard Bluetooth SIG base UUID`() {
+    fun `camera control service UUID matches documentation`() {
+        assertEquals(
+            Uuid.parse("8000CC00-CC00-FFFF-FFFF-FFFFFFFFFFFF"),
+            SonyGattSpec.CAMERA_CONTROL_SERVICE_UUID,
+        )
+    }
+
+    // ==================== Location Service (DD) Characteristic Tests ====================
+
+    @Test
+    fun `location status notify characteristic UUID (DD01) matches documentation`() {
+        assertEquals(
+            Uuid.parse("0000DD01-0000-1000-8000-00805f9b34fb"),
+            SonyGattSpec.LOCATION_STATUS_NOTIFY_CHARACTERISTIC_UUID,
+        )
+    }
+
+    @Test
+    fun `location data write characteristic UUID (DD11) matches documentation`() {
+        assertEquals(
+            Uuid.parse("0000DD11-0000-1000-8000-00805f9b34fb"),
+            SonyGattSpec.LOCATION_DATA_WRITE_CHARACTERISTIC_UUID,
+        )
+    }
+
+    @Test
+    fun `location config read characteristic UUID (DD21) matches documentation`() {
+        assertEquals(
+            Uuid.parse("0000DD21-0000-1000-8000-00805f9b34fb"),
+            SonyGattSpec.LOCATION_CONFIG_READ_CHARACTERISTIC_UUID,
+        )
+    }
+
+    @Test
+    fun `location lock characteristic UUID (DD30) matches documentation`() {
+        assertEquals(
+            Uuid.parse("0000DD30-0000-1000-8000-00805f9b34fb"),
+            SonyGattSpec.LOCATION_LOCK_CHARACTERISTIC_UUID,
+        )
+    }
+
+    @Test
+    fun `location enable characteristic UUID (DD31) matches documentation`() {
+        assertEquals(
+            Uuid.parse("0000DD31-0000-1000-8000-00805f9b34fb"),
+            SonyGattSpec.LOCATION_ENABLE_CHARACTERISTIC_UUID,
+        )
+    }
+
+    @Test
+    fun `time correction characteristic UUID (DD32) matches documentation`() {
+        assertEquals(
+            Uuid.parse("0000DD32-0000-1000-8000-00805f9b34fb"),
+            SonyGattSpec.TIME_CORRECTION_CHARACTERISTIC_UUID,
+        )
+    }
+
+    @Test
+    fun `area adjustment characteristic UUID (DD33) matches documentation`() {
+        assertEquals(
+            Uuid.parse("0000DD33-0000-1000-8000-00805f9b34fb"),
+            SonyGattSpec.AREA_ADJUSTMENT_CHARACTERISTIC_UUID,
+        )
+    }
+
+    // ==================== Pairing Service (EE) Characteristic Tests ====================
+
+    @Test
+    fun `pairing characteristic UUID (EE01) uses standard Bluetooth SIG base UUID`() {
         // Note: While Sony services use a custom UUID format, the characteristics
         // within those services use the standard Bluetooth SIG base UUID format.
         assertEquals(
@@ -82,6 +124,58 @@ class SonyGattSpecTest {
             SonyGattSpec.PAIRING_CHARACTERISTIC_UUID,
         )
     }
+
+    // ==================== Camera Control Service (CC) Characteristic Tests ====================
+
+    @Test
+    fun `time completion status characteristic UUID (CC09) matches documentation`() {
+        assertEquals(
+            Uuid.parse("0000CC09-0000-1000-8000-00805f9b34fb"),
+            SonyGattSpec.TIME_COMPLETION_STATUS_CHARACTERISTIC_UUID,
+        )
+    }
+
+    @Test
+    fun `firmware version characteristic UUID (CC0A) matches documentation`() {
+        assertEquals(
+            Uuid.parse("0000CC0A-0000-1000-8000-00805f9b34fb"),
+            SonyGattSpec.FIRMWARE_VERSION_CHARACTERISTIC_UUID,
+        )
+    }
+
+    @Test
+    fun `model name characteristic UUID (CC0B) matches documentation`() {
+        assertEquals(
+            Uuid.parse("0000CC0B-0000-1000-8000-00805f9b34fb"),
+            SonyGattSpec.MODEL_NAME_CHARACTERISTIC_UUID,
+        )
+    }
+
+    @Test
+    fun `datetime notify characteristic UUID (CC0E) matches documentation`() {
+        assertEquals(
+            Uuid.parse("0000CC0E-0000-1000-8000-00805f9b34fb"),
+            SonyGattSpec.DATETIME_NOTIFY_CHARACTERISTIC_UUID,
+        )
+    }
+
+    @Test
+    fun `date format characteristic UUID (CC12) matches documentation`() {
+        assertEquals(
+            Uuid.parse("0000CC12-0000-1000-8000-00805f9b34fb"),
+            SonyGattSpec.DATE_FORMAT_CHARACTERISTIC_UUID,
+        )
+    }
+
+    @Test
+    fun `time area setting characteristic UUID (CC13) matches documentation`() {
+        assertEquals(
+            Uuid.parse("0000CC13-0000-1000-8000-00805f9b34fb"),
+            SonyGattSpec.TIME_AREA_SETTING_CHARACTERISTIC_UUID,
+        )
+    }
+
+    // ==================== CameraGattSpec Override Tests ====================
 
     @Test
     fun `scan filter uses remote control and pairing service UUIDs`() {
@@ -93,16 +187,36 @@ class SonyGattSpecTest {
     }
 
     @Test
-    fun `dateTime uses location service and data write characteristic`() {
-        assertEquals(SonyGattSpec.LOCATION_SERVICE_UUID, SonyGattSpec.dateTimeServiceUuid)
+    fun `scan filter device names includes ILCE prefix`() {
+        assertEquals(listOf("ILCE-"), SonyGattSpec.scanFilterDeviceNames)
+    }
+
+    @Test
+    fun `dateTime uses Camera Control Service and CC13 characteristic`() {
+        assertEquals(SonyGattSpec.CAMERA_CONTROL_SERVICE_UUID, SonyGattSpec.dateTimeServiceUuid)
         assertEquals(
-            SonyGattSpec.LOCATION_DATA_WRITE_CHARACTERISTIC_UUID,
+            SonyGattSpec.TIME_AREA_SETTING_CHARACTERISTIC_UUID,
             SonyGattSpec.dateTimeCharacteristicUuid,
         )
     }
 
     @Test
-    fun `location uses location service and data write characteristic`() {
+    fun `dateTime characteristic is NOT the same as location characteristic`() {
+        // Critical test: These must be different to avoid timestamp overwrite issues
+        assertNotEquals(
+            SonyGattSpec.dateTimeCharacteristicUuid,
+            SonyGattSpec.locationCharacteristicUuid,
+        )
+    }
+
+    @Test
+    fun `dateTime service is NOT the same as location service`() {
+        // CC service for date/time, DD service for location
+        assertNotEquals(SonyGattSpec.dateTimeServiceUuid, SonyGattSpec.locationServiceUuid)
+    }
+
+    @Test
+    fun `location uses Location Service and DD11 characteristic`() {
         assertEquals(SonyGattSpec.LOCATION_SERVICE_UUID, SonyGattSpec.locationServiceUuid)
         assertEquals(
             SonyGattSpec.LOCATION_DATA_WRITE_CHARACTERISTIC_UUID,
@@ -117,37 +231,10 @@ class SonyGattSpecTest {
 
     @Test
     fun `firmware uses Camera Control Service`() {
+        assertEquals(SonyGattSpec.CAMERA_CONTROL_SERVICE_UUID, SonyGattSpec.firmwareServiceUuid)
         assertEquals(
-            Uuid.parse("8000CC00-CC00-FFFF-FFFF-FFFFFFFFFFFF"),
-            SonyGattSpec.firmwareServiceUuid,
-        )
-        assertEquals(
-            Uuid.parse("0000CC0A-0000-1000-8000-00805f9b34fb"),
-            SonyGattSpec.firmwareVersionCharacteristicUuid,
-        )
-    }
-
-    @Test
-    fun `camera control service UUID matches documentation`() {
-        assertEquals(
-            Uuid.parse("8000CC00-CC00-FFFF-FFFF-FFFFFFFFFFFF"),
-            SonyGattSpec.CAMERA_CONTROL_SERVICE_UUID,
-        )
-    }
-
-    @Test
-    fun `firmware version characteristic UUID matches documentation`() {
-        assertEquals(
-            Uuid.parse("0000CC0A-0000-1000-8000-00805f9b34fb"),
             SonyGattSpec.FIRMWARE_VERSION_CHARACTERISTIC_UUID,
-        )
-    }
-
-    @Test
-    fun `model name characteristic UUID matches documentation`() {
-        assertEquals(
-            Uuid.parse("0000CC0B-0000-1000-8000-00805f9b34fb"),
-            SonyGattSpec.MODEL_NAME_CHARACTERISTIC_UUID,
+            SonyGattSpec.firmwareVersionCharacteristicUuid,
         )
     }
 
@@ -155,5 +242,71 @@ class SonyGattSpecTest {
     fun `device name is not supported`() {
         assertNull(SonyGattSpec.deviceNameServiceUuid)
         assertNull(SonyGattSpec.deviceNameCharacteristicUuid)
+    }
+
+    @Test
+    fun `pairing uses Pairing Service and EE01 characteristic`() {
+        assertEquals(SonyGattSpec.PAIRING_SERVICE_UUID, SonyGattSpec.pairingServiceUuid)
+        assertEquals(
+            SonyGattSpec.PAIRING_CHARACTERISTIC_UUID,
+            SonyGattSpec.pairingCharacteristicUuid,
+        )
+    }
+
+    // ==================== UUID Format Verification Tests ====================
+
+    @Test
+    fun `all service UUIDs use Sony custom format`() {
+        // Sony services use format: 8000xxxx-xxxx-FFFF-FFFF-FFFFFFFFFFFF
+        val serviceUuids =
+            listOf(
+                SonyGattSpec.REMOTE_CONTROL_SERVICE_UUID,
+                SonyGattSpec.LOCATION_SERVICE_UUID,
+                SonyGattSpec.PAIRING_SERVICE_UUID,
+                SonyGattSpec.CAMERA_CONTROL_SERVICE_UUID,
+            )
+
+        for (uuid in serviceUuids) {
+            val uuidString = uuid.toString().uppercase()
+            assert(uuidString.startsWith("8000")) {
+                "Service UUID should start with 8000: $uuidString"
+            }
+            assert(uuidString.endsWith("FFFF-FFFF-FFFFFFFFFFFF")) {
+                "Service UUID should end with FFFF-FFFF-FFFFFFFFFFFF: $uuidString"
+            }
+        }
+    }
+
+    @Test
+    fun `all characteristic UUIDs use standard Bluetooth SIG base format`() {
+        // Characteristics use format: 0000xxxx-0000-1000-8000-00805f9b34fb
+        val characteristicUuids =
+            listOf(
+                SonyGattSpec.LOCATION_STATUS_NOTIFY_CHARACTERISTIC_UUID,
+                SonyGattSpec.LOCATION_DATA_WRITE_CHARACTERISTIC_UUID,
+                SonyGattSpec.LOCATION_CONFIG_READ_CHARACTERISTIC_UUID,
+                SonyGattSpec.LOCATION_LOCK_CHARACTERISTIC_UUID,
+                SonyGattSpec.LOCATION_ENABLE_CHARACTERISTIC_UUID,
+                SonyGattSpec.TIME_CORRECTION_CHARACTERISTIC_UUID,
+                SonyGattSpec.AREA_ADJUSTMENT_CHARACTERISTIC_UUID,
+                SonyGattSpec.PAIRING_CHARACTERISTIC_UUID,
+                SonyGattSpec.TIME_COMPLETION_STATUS_CHARACTERISTIC_UUID,
+                SonyGattSpec.FIRMWARE_VERSION_CHARACTERISTIC_UUID,
+                SonyGattSpec.MODEL_NAME_CHARACTERISTIC_UUID,
+                SonyGattSpec.DATETIME_NOTIFY_CHARACTERISTIC_UUID,
+                SonyGattSpec.DATE_FORMAT_CHARACTERISTIC_UUID,
+                SonyGattSpec.TIME_AREA_SETTING_CHARACTERISTIC_UUID,
+            )
+
+        val bluetoothSigSuffix = "0000-1000-8000-00805F9B34FB"
+        for (uuid in characteristicUuids) {
+            val uuidString = uuid.toString().uppercase()
+            assert(uuidString.startsWith("0000")) {
+                "Characteristic UUID should start with 0000: $uuidString"
+            }
+            assert(uuidString.endsWith(bluetoothSigSuffix)) {
+                "Characteristic UUID should end with Bluetooth SIG base: $uuidString"
+            }
+        }
     }
 }

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/vendors/sony/SonyProtocolTest.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/vendors/sony/SonyProtocolTest.kt
@@ -506,6 +506,22 @@ class SonyProtocolTest {
     // ==================== Round-trip Tests ====================
 
     @Test
+    fun `encodeDateTime handles fractional timezone offset near zero`() {
+        // UTC-0:30 = 0 hours, -30 minutes
+        // This follows Sony's buggy behavior: offsetHours becomes 0, losing the negative sign.
+        val dateTime =
+            ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.ofHoursMinutes(0, -30))
+        val encoded = SonyProtocol.encodeDateTime(dateTime)
+        val decoded = SonyProtocol.decodeDateTime(encoded)
+
+        // It incorrectly decodes as +00:30 because the sign was lost in encoding
+        assertTrue(
+            "Decoded string should contain UTC+00:30 due to Sony's bug, but was: $decoded",
+            decoded.contains("+00:30"),
+        )
+    }
+
+    @Test
     fun `CC13 encode-decode round trip preserves data`() {
         val dateTime = ZonedDateTime.of(2024, 6, 15, 10, 25, 30, 0, ZoneOffset.ofHours(-5))
         val encoded = SonyProtocol.encodeDateTime(dateTime)

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/vendors/sony/SonyProtocolTest.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/vendors/sony/SonyProtocolTest.kt
@@ -3,6 +3,7 @@ package dev.sebastiano.camerasync.vendors.sony
 import dev.sebastiano.camerasync.domain.model.GpsLocation
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import org.junit.Assert.assertArrayEquals
@@ -11,140 +12,265 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+/**
+ * Comprehensive tests for [SonyProtocol] implementation.
+ *
+ * These tests verify:
+ * - CC13 Time Area Setting encoding (13-byte packet for date/time sync)
+ * - DD11 Location packet encoding (91/95-byte packet for GPS sync)
+ * - Big-Endian byte order for all multi-byte values (critical for Sony protocol)
+ * - Decoding of both packet formats
+ * - Edge cases and boundary conditions
+ *
+ * See docs/sony/DATETIME_GPS_SYNC.md for protocol documentation.
+ */
 class SonyProtocolTest {
 
+    // ==================== CC13 Time Area Setting Tests ====================
+
     @Test
-    fun `encodeDateTime produces 95 bytes with timezone`() {
+    fun `encodeDateTime produces 13-byte CC13 packet`() {
         val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC)
         val encoded = SonyProtocol.encodeDateTime(dateTime)
+        assertEquals("CC13 packet should be exactly 13 bytes", 13, encoded.size)
+    }
+
+    @Test
+    fun `encodeDateTime sets correct CC13 header`() {
+        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC)
+        val encoded = SonyProtocol.encodeDateTime(dateTime)
+
+        // Bytes 0-2: Header 0x0C 0x00 0x00
+        assertEquals(0x0C.toByte(), encoded[0])
+        assertEquals(0x00.toByte(), encoded[1])
+        assertEquals(0x00.toByte(), encoded[2])
+    }
+
+    @Test
+    fun `encodeDateTime uses Big-Endian for year`() {
+        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC)
+        val encoded = SonyProtocol.encodeDateTime(dateTime)
+
+        // Year 2024 = 0x07E8 in hex
+        // Big-Endian: high byte first = 0x07, 0xE8
+        assertEquals(0x07.toByte(), encoded[3]) // High byte
+        assertEquals(0xE8.toByte(), encoded[4]) // Low byte
+
+        // Verify by reading as Big-Endian
+        val buffer = ByteBuffer.wrap(encoded).order(ByteOrder.BIG_ENDIAN)
+        buffer.position(3)
+        assertEquals(2024, buffer.short.toInt() and 0xFFFF)
+    }
+
+    @Test
+    fun `encodeDateTime sets correct date components`() {
+        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC)
+        val encoded = SonyProtocol.encodeDateTime(dateTime)
+
+        assertEquals(12, encoded[5].toInt() and 0xFF) // Month
+        assertEquals(25, encoded[6].toInt() and 0xFF) // Day
+        assertEquals(14, encoded[7].toInt() and 0xFF) // Hour
+        assertEquals(30, encoded[8].toInt() and 0xFF) // Minute
+        assertEquals(45, encoded[9].toInt() and 0xFF) // Second
+    }
+
+    @Test
+    fun `encodeDateTime sets DST flag to 0 for standard time`() {
+        // UTC has no DST
+        val dateTime = ZonedDateTime.of(2024, 1, 15, 12, 0, 0, 0, ZoneOffset.UTC)
+        val encoded = SonyProtocol.encodeDateTime(dateTime)
+
+        assertEquals(0x00.toByte(), encoded[10])
+    }
+
+    @Test
+    fun `encodeDateTime sets DST flag to 1 during daylight saving time`() {
+        // Use a timezone that observes DST, during summer
+        val dstZone = ZoneId.of("America/New_York")
+        val dateTime = ZonedDateTime.of(2024, 7, 15, 12, 0, 0, 0, dstZone)
+        val encoded = SonyProtocol.encodeDateTime(dateTime)
+
+        assertEquals(0x01.toByte(), encoded[10])
+    }
+
+    @Test
+    fun `encodeDateTime uses split format for timezone offset`() {
+        // UTC+8 = +8 hours, 0 minutes
+        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.ofHours(8))
+        val encoded = SonyProtocol.encodeDateTime(dateTime)
+
+        // Byte 11: Signed hours = +8
+        // Byte 12: Minutes = 0
+        assertEquals(8.toByte(), encoded[11])
+        assertEquals(0.toByte(), encoded[12])
+    }
+
+    @Test
+    fun `encodeDateTime handles negative timezone offset`() {
+        // UTC-5 = -5 hours, 0 minutes
+        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.ofHours(-5))
+        val encoded = SonyProtocol.encodeDateTime(dateTime)
+
+        // Byte 11: Signed hours = -5
+        // Byte 12: Minutes = 0
+        assertEquals((-5).toByte(), encoded[11])
+        assertEquals(0.toByte(), encoded[12])
+    }
+
+    @Test
+    fun `encodeDateTime handles UTC timezone`() {
+        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC)
+        val encoded = SonyProtocol.encodeDateTime(dateTime)
+
+        assertEquals(0.toByte(), encoded[11]) // Hours
+        assertEquals(0.toByte(), encoded[12]) // Minutes
+    }
+
+    @Test
+    fun `encodeDateTime handles fractional timezone offset`() {
+        // UTC+5:30 (India) = +5 hours, 30 minutes
+        val dateTime =
+            ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.ofHoursMinutes(5, 30))
+        val encoded = SonyProtocol.encodeDateTime(dateTime)
+
+        assertEquals(5.toByte(), encoded[11]) // Hours
+        assertEquals(30.toByte(), encoded[12]) // Minutes
+    }
+
+    @Test
+    fun `encodeDateTime preserves local time not UTC`() {
+        // CC13 uses local time, not UTC
+        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.ofHours(8))
+        val encoded = SonyProtocol.encodeDateTime(dateTime)
+
+        val buffer = ByteBuffer.wrap(encoded).order(ByteOrder.BIG_ENDIAN)
+        buffer.position(3)
+        assertEquals(2024, buffer.short.toInt() and 0xFFFF)
+        assertEquals(12, buffer.get().toInt() and 0xFF)
+        assertEquals(25, buffer.get().toInt() and 0xFF)
+        assertEquals(14, buffer.get().toInt() and 0xFF) // Local hour, not UTC
+        assertEquals(30, buffer.get().toInt() and 0xFF)
+        assertEquals(45, buffer.get().toInt() and 0xFF)
+    }
+
+    // ==================== DD11 Location Packet Tests ====================
+
+    @Test
+    fun `encodeLocation produces 95 bytes with timezone`() {
+        val location =
+            GpsLocation(
+                latitude = 37.7749,
+                longitude = -122.4194,
+                altitude = 10.0,
+                timestamp = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC),
+            )
+        val encoded = SonyProtocol.encodeLocation(location)
         assertEquals(95, encoded.size)
     }
 
     @Test
-    fun `encodeDateTime sets correct payload length`() {
-        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC)
-        val encoded = SonyProtocol.encodeDateTime(dateTime)
+    fun `encodeLocationPacket without timezone produces 91 bytes`() {
+        val packet =
+            SonyProtocol.encodeLocationPacket(
+                latitude = 0.0,
+                longitude = 0.0,
+                dateTime = ZonedDateTime.now(ZoneOffset.UTC),
+                includeTimezone = false,
+            )
+        assertEquals(91, packet.size)
+    }
 
-        val buffer = ByteBuffer.wrap(encoded).order(ByteOrder.BIG_ENDIAN)
-        // Payload length should be 93 (95 - 2 bytes for length field)
+    @Test
+    fun `encodeLocationPacket uses Big-Endian for payload length`() {
+        val packet =
+            SonyProtocol.encodeLocationPacket(
+                latitude = 0.0,
+                longitude = 0.0,
+                dateTime = ZonedDateTime.now(ZoneOffset.UTC),
+                includeTimezone = true,
+            )
+
+        // Payload length 93 = 0x005D
+        // Big-Endian: 0x00, 0x5D (high byte first)
+        assertEquals(0x00.toByte(), packet[0])
+        assertEquals(0x5D.toByte(), packet[1])
+
+        val buffer = ByteBuffer.wrap(packet).order(ByteOrder.BIG_ENDIAN)
         assertEquals(93, buffer.short.toInt())
     }
 
     @Test
-    fun `encodeDateTime sets correct fixed header`() {
-        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC)
-        val encoded = SonyProtocol.encodeDateTime(dateTime)
+    fun `encodeLocationPacket sets correct fixed header`() {
+        val packet =
+            SonyProtocol.encodeLocationPacket(
+                latitude = 0.0,
+                longitude = 0.0,
+                dateTime = ZonedDateTime.now(ZoneOffset.UTC),
+                includeTimezone = true,
+            )
 
         // Bytes 2-4: Fixed header 0x08 0x02 0xFC
-        assertEquals(0x08.toByte(), encoded[2])
-        assertEquals(0x02.toByte(), encoded[3])
-        assertEquals(0xFC.toByte(), encoded[4])
+        assertEquals(0x08.toByte(), packet[2])
+        assertEquals(0x02.toByte(), packet[3])
+        assertEquals(0xFC.toByte(), packet[4])
     }
 
     @Test
-    fun `encodeDateTime sets timezone flag to include`() {
-        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC)
-        val encoded = SonyProtocol.encodeDateTime(dateTime)
+    fun `encodeLocationPacket sets timezone flag correctly`() {
+        val withTz =
+            SonyProtocol.encodeLocationPacket(
+                latitude = 0.0,
+                longitude = 0.0,
+                dateTime = ZonedDateTime.now(ZoneOffset.UTC),
+                includeTimezone = true,
+            )
+        assertEquals(0x03.toByte(), withTz[5])
 
-        // Byte 5: Timezone flag (0x03 = include)
-        assertEquals(0x03.toByte(), encoded[5])
+        val withoutTz =
+            SonyProtocol.encodeLocationPacket(
+                latitude = 0.0,
+                longitude = 0.0,
+                dateTime = ZonedDateTime.now(ZoneOffset.UTC),
+                includeTimezone = false,
+            )
+        assertEquals(0x00.toByte(), withoutTz[5])
     }
 
     @Test
-    fun `encodeDateTime sets correct fixed data bytes`() {
-        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC)
-        val encoded = SonyProtocol.encodeDateTime(dateTime)
+    fun `encodeLocationPacket sets correct padding bytes`() {
+        val packet =
+            SonyProtocol.encodeLocationPacket(
+                latitude = 0.0,
+                longitude = 0.0,
+                dateTime = ZonedDateTime.now(ZoneOffset.UTC),
+                includeTimezone = true,
+            )
 
-        // Bytes 6-10: Fixed data 0x00 0x00 0x10 0x10 0x10
-        assertEquals(0x00.toByte(), encoded[6])
-        assertEquals(0x00.toByte(), encoded[7])
-        assertEquals(0x10.toByte(), encoded[8])
-        assertEquals(0x10.toByte(), encoded[9])
-        assertEquals(0x10.toByte(), encoded[10])
+        // Bytes 6-7: Padding (zeros)
+        // Bytes 8-10: Fixed padding (0x10)
+        assertEquals(0x00.toByte(), packet[6])
+        assertEquals(0x00.toByte(), packet[7])
+        assertEquals(0x10.toByte(), packet[8])
+        assertEquals(0x10.toByte(), packet[9])
+        assertEquals(0x10.toByte(), packet[10])
     }
 
     @Test
-    fun `encodeDateTime sets zero coordinates for time-only`() {
-        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC)
-        val encoded = SonyProtocol.encodeDateTime(dateTime)
-
-        val buffer = ByteBuffer.wrap(encoded).order(ByteOrder.BIG_ENDIAN)
-        buffer.position(11)
-        assertEquals(0, buffer.int) // Latitude
-        assertEquals(0, buffer.int) // Longitude
-    }
-
-    @Test
-    fun `encodeDateTime sets correct UTC timestamp`() {
-        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC)
-        val encoded = SonyProtocol.encodeDateTime(dateTime)
-
-        val buffer = ByteBuffer.wrap(encoded).order(ByteOrder.BIG_ENDIAN)
-        buffer.position(19)
-        assertEquals(2024, buffer.short.toInt()) // Year
-        assertEquals(12, buffer.get().toInt()) // Month
-        assertEquals(25, buffer.get().toInt()) // Day
-        assertEquals(14, buffer.get().toInt()) // Hour
-        assertEquals(30, buffer.get().toInt()) // Minute
-        assertEquals(45, buffer.get().toInt()) // Second
-    }
-
-    @Test
-    fun `encodeDateTime converts local time to UTC`() {
-        // 14:30 in UTC+8 should become 06:30 UTC
-        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.ofHours(8))
-        val encoded = SonyProtocol.encodeDateTime(dateTime)
-
-        val buffer = ByteBuffer.wrap(encoded).order(ByteOrder.BIG_ENDIAN)
-        buffer.position(19)
-        assertEquals(2024, buffer.short.toInt())
-        assertEquals(12, buffer.get().toInt())
-        assertEquals(25, buffer.get().toInt())
-        assertEquals(6, buffer.get().toInt()) // 14 - 8 = 6
-        assertEquals(30, buffer.get().toInt())
-        assertEquals(45, buffer.get().toInt())
-    }
-
-    @Test
-    fun `encodeDateTime sets correct timezone offset`() {
-        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.ofHours(8))
-        val encoded = SonyProtocol.encodeDateTime(dateTime)
-
-        val buffer = ByteBuffer.wrap(encoded).order(ByteOrder.BIG_ENDIAN)
-        buffer.position(91)
-        // UTC+8 = 480 minutes
-        assertEquals(480, buffer.short.toInt())
-        assertEquals(0, buffer.short.toInt()) // DST offset
-    }
-
-    @Test
-    fun `encodeLocation produces 95 bytes`() {
-        val location =
-            GpsLocation(
+    fun `encodeLocationPacket uses Big-Endian for coordinates`() {
+        // San Francisco: 37.7749, -122.4194
+        // Latitude * 10,000,000 = 377,749,000 = 0x168429B8
+        // Big-Endian: 16, 84, 29, B8
+        val packet =
+            SonyProtocol.encodeLocationPacket(
                 latitude = 37.7749,
                 longitude = -122.4194,
-                altitude = 10.0,
-                timestamp = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC),
+                dateTime = ZonedDateTime.now(ZoneOffset.UTC),
+                includeTimezone = true,
             )
-        val encoded = SonyProtocol.encodeLocation(location)
-        assertEquals(95, encoded.size)
-    }
 
-    @Test
-    fun `encodeLocation sets correct coordinates`() {
-        val location =
-            GpsLocation(
-                latitude = 37.7749,
-                longitude = -122.4194,
-                altitude = 10.0,
-                timestamp = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC),
-            )
-        val encoded = SonyProtocol.encodeLocation(location)
-
-        val buffer = ByteBuffer.wrap(encoded).order(ByteOrder.BIG_ENDIAN)
+        val buffer = ByteBuffer.wrap(packet).order(ByteOrder.BIG_ENDIAN)
         buffer.position(11)
 
-        // Coordinates scaled by 10,000,000
         val expectedLat = (37.7749 * 10_000_000).toInt()
         val expectedLon = (-122.4194 * 10_000_000).toInt()
 
@@ -153,17 +279,17 @@ class SonyProtocolTest {
     }
 
     @Test
-    fun `encodeLocation handles negative coordinates`() {
-        val location =
-            GpsLocation(
+    fun `encodeLocationPacket handles negative latitude correctly`() {
+        // Sydney: -33.8688
+        val packet =
+            SonyProtocol.encodeLocationPacket(
                 latitude = -33.8688,
                 longitude = 151.2093,
-                altitude = 0.0,
-                timestamp = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC),
+                dateTime = ZonedDateTime.now(ZoneOffset.UTC),
+                includeTimezone = true,
             )
-        val encoded = SonyProtocol.encodeLocation(location)
 
-        val buffer = ByteBuffer.wrap(encoded).order(ByteOrder.BIG_ENDIAN)
+        val buffer = ByteBuffer.wrap(packet).order(ByteOrder.BIG_ENDIAN)
         buffer.position(11)
 
         val expectedLat = (-33.8688 * 10_000_000).toInt()
@@ -171,6 +297,171 @@ class SonyProtocolTest {
 
         assertEquals(expectedLat, buffer.int)
         assertEquals(expectedLon, buffer.int)
+    }
+
+    @Test
+    fun `encodeLocationPacket uses Big-Endian for year`() {
+        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC)
+        val packet =
+            SonyProtocol.encodeLocationPacket(
+                latitude = 0.0,
+                longitude = 0.0,
+                dateTime = dateTime,
+                includeTimezone = true,
+            )
+
+        // Year at offset 19
+        val buffer = ByteBuffer.wrap(packet).order(ByteOrder.BIG_ENDIAN)
+        buffer.position(19)
+        assertEquals(2024, buffer.short.toInt() and 0xFFFF)
+    }
+
+    @Test
+    fun `encodeLocationPacket converts to UTC`() {
+        // DD11 uses UTC time (per Sony decompiled code)
+        // 14:30 in UTC+8 should become 06:30 UTC
+        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.ofHours(8))
+        val packet =
+            SonyProtocol.encodeLocationPacket(
+                latitude = 0.0,
+                longitude = 0.0,
+                dateTime = dateTime,
+                includeTimezone = true,
+            )
+
+        val buffer = ByteBuffer.wrap(packet).order(ByteOrder.BIG_ENDIAN)
+        buffer.position(19)
+        assertEquals(2024, buffer.short.toInt() and 0xFFFF)
+        assertEquals(12, buffer.get().toInt() and 0xFF)
+        assertEquals(25, buffer.get().toInt() and 0xFF)
+        assertEquals(6, buffer.get().toInt() and 0xFF) // 14 - 8 = 6 UTC
+        assertEquals(30, buffer.get().toInt() and 0xFF)
+        assertEquals(45, buffer.get().toInt() and 0xFF)
+    }
+
+    @Test
+    fun `encodeLocationPacket uses system timezone for offset`() {
+        // The timezone offset now uses the system default timezone,
+        // not the dateTime's offset (GPS timestamps are typically UTC)
+        val dateTime = ZonedDateTime.now(ZoneOffset.UTC)
+        val packet =
+            SonyProtocol.encodeLocationPacket(
+                latitude = 0.0,
+                longitude = 0.0,
+                dateTime = dateTime,
+                includeTimezone = true,
+            )
+
+        // Calculate expected values from system timezone
+        val systemZone = java.time.ZoneId.systemDefault()
+        val now = java.time.Instant.now()
+        val zoneRules = systemZone.rules
+        val standardOffset = zoneRules.getStandardOffset(now)
+        val actualOffset = zoneRules.getOffset(now)
+
+        val expectedTzMinutes = standardOffset.totalSeconds / 60
+        val expectedDstMinutes = (actualOffset.totalSeconds - standardOffset.totalSeconds) / 60
+
+        val buffer = ByteBuffer.wrap(packet).order(ByteOrder.BIG_ENDIAN)
+        buffer.position(91)
+        assertEquals(expectedTzMinutes.toShort(), buffer.short) // System TZ offset in minutes
+        assertEquals(expectedDstMinutes.toShort(), buffer.short) // DST offset
+    }
+
+    @Test
+    fun `encodeLocationPacket handles extreme coordinates`() {
+        // North Pole
+        val northPole =
+            SonyProtocol.encodeLocationPacket(
+                latitude = 90.0,
+                longitude = 0.0,
+                dateTime = ZonedDateTime.now(ZoneOffset.UTC),
+                includeTimezone = false,
+            )
+        var buffer = ByteBuffer.wrap(northPole).order(ByteOrder.BIG_ENDIAN)
+        buffer.position(11)
+        assertEquals(900_000_000, buffer.int)
+
+        // South Pole
+        val southPole =
+            SonyProtocol.encodeLocationPacket(
+                latitude = -90.0,
+                longitude = 0.0,
+                dateTime = ZonedDateTime.now(ZoneOffset.UTC),
+                includeTimezone = false,
+            )
+        buffer = ByteBuffer.wrap(southPole).order(ByteOrder.BIG_ENDIAN)
+        buffer.position(11)
+        assertEquals(-900_000_000, buffer.int)
+
+        // International Date Line
+        val dateLine =
+            SonyProtocol.encodeLocationPacket(
+                latitude = 0.0,
+                longitude = 180.0,
+                dateTime = ZonedDateTime.now(ZoneOffset.UTC),
+                includeTimezone = false,
+            )
+        buffer = ByteBuffer.wrap(dateLine).order(ByteOrder.BIG_ENDIAN)
+        buffer.position(15)
+        assertEquals(1_800_000_000, buffer.int)
+
+        val negDateLine =
+            SonyProtocol.encodeLocationPacket(
+                latitude = 0.0,
+                longitude = -180.0,
+                dateTime = ZonedDateTime.now(ZoneOffset.UTC),
+                includeTimezone = false,
+            )
+        buffer = ByteBuffer.wrap(negDateLine).order(ByteOrder.BIG_ENDIAN)
+        buffer.position(15)
+        assertEquals(-1_800_000_000, buffer.int)
+    }
+
+    // ==================== Decode Tests ====================
+
+    @Test
+    fun `decodeDateTime handles CC13 format`() {
+        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.ofHours(8))
+        val encoded = SonyProtocol.encodeDateTime(dateTime)
+        val decoded = SonyProtocol.decodeDateTime(encoded)
+
+        assertTrue("Should contain year", decoded.contains("2024"))
+        assertTrue("Should contain month-day", decoded.contains("12-25"))
+        assertTrue("Should contain time", decoded.contains("14:30:45"))
+    }
+
+    @Test
+    fun `decodeDateTime handles DD11 format`() {
+        val location =
+            GpsLocation(
+                latitude = 37.7749,
+                longitude = -122.4194,
+                altitude = 0.0,
+                timestamp = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC),
+            )
+        val encoded = SonyProtocol.encodeLocation(location)
+        val decoded = SonyProtocol.decodeDateTime(encoded)
+
+        // DD11 uses UTC time
+        assertTrue("Should contain date", decoded.contains("2024-12-25"))
+        assertTrue("Should contain time", decoded.contains("14:30:45"))
+    }
+
+    @Test
+    fun `decodeDateTime returns error for invalid size`() {
+        val decoded = SonyProtocol.decodeDateTime(ByteArray(10))
+        assertTrue("Should indicate invalid data", decoded.contains("Invalid data"))
+    }
+
+    @Test
+    fun `decodeDateTime shows DST indicator when set`() {
+        val dstZone = ZoneId.of("America/New_York")
+        val dateTime = ZonedDateTime.of(2024, 7, 15, 12, 0, 0, 0, dstZone)
+        val encoded = SonyProtocol.encodeDateTime(dateTime)
+        val decoded = SonyProtocol.decodeDateTime(encoded)
+
+        assertTrue("Should indicate DST", decoded.contains("DST"))
     }
 
     @Test
@@ -191,19 +482,19 @@ class SonyProtocolTest {
     }
 
     @Test
-    fun `decodeDateTime correctly decodes encoded time`() {
-        val dateTime = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC)
-        val encoded = SonyProtocol.encodeDateTime(dateTime)
-        val decoded = SonyProtocol.decodeDateTime(encoded)
+    fun `decodeLocation handles negative coordinates`() {
+        val location =
+            GpsLocation(
+                latitude = -33.8688,
+                longitude = 151.2093,
+                altitude = 0.0,
+                timestamp = ZonedDateTime.of(2024, 12, 25, 14, 30, 45, 0, ZoneOffset.UTC),
+            )
+        val encoded = SonyProtocol.encodeLocation(location)
+        val decoded = SonyProtocol.decodeLocation(encoded)
 
-        assertTrue("Decoded string should contain date", decoded.contains("2024-12-25"))
-        assertTrue("Decoded string should contain time", decoded.contains("14:30:45"))
-    }
-
-    @Test
-    fun `decodeDateTime returns error for short data`() {
-        val decoded = SonyProtocol.decodeDateTime(ByteArray(10))
-        assertTrue("Should indicate invalid data", decoded.contains("Invalid data"))
+        assertTrue("Should contain negative latitude", decoded.contains("-33.8688"))
+        assertTrue("Should contain positive longitude", decoded.contains("151.2093"))
     }
 
     @Test
@@ -212,40 +503,73 @@ class SonyProtocolTest {
         assertTrue("Should indicate invalid data", decoded.contains("Invalid data"))
     }
 
+    // ==================== Round-trip Tests ====================
+
     @Test
-    fun `encodeLocationPacket without timezone produces 91 bytes`() {
-        val packet =
-            SonyProtocol.encodeLocationPacket(
-                latitude = 0.0,
-                longitude = 0.0,
-                dateTime = ZonedDateTime.now(ZoneOffset.UTC),
-                includeTimezone = false,
-            )
-        assertEquals(91, packet.size)
+    fun `CC13 encode-decode round trip preserves data`() {
+        val dateTime = ZonedDateTime.of(2024, 6, 15, 10, 25, 30, 0, ZoneOffset.ofHours(-5))
+        val encoded = SonyProtocol.encodeDateTime(dateTime)
+
+        // Manually verify the round trip by reading bytes
+        val buffer = ByteBuffer.wrap(encoded).order(ByteOrder.BIG_ENDIAN)
+        buffer.position(3)
+        assertEquals(2024, buffer.short.toInt() and 0xFFFF)
+        assertEquals(6, buffer.get().toInt() and 0xFF)
+        assertEquals(15, buffer.get().toInt() and 0xFF)
+        assertEquals(10, buffer.get().toInt() and 0xFF)
+        assertEquals(25, buffer.get().toInt() and 0xFF)
+        assertEquals(30, buffer.get().toInt() and 0xFF)
+        buffer.get() // DST flag
+        assertEquals(-5, buffer.get().toInt()) // Hours (signed)
+        assertEquals(0, buffer.get().toInt() and 0xFF) // Minutes
     }
 
     @Test
-    fun `encodeLocationPacket without timezone sets correct flag`() {
-        val packet =
-            SonyProtocol.encodeLocationPacket(
-                latitude = 0.0,
-                longitude = 0.0,
-                dateTime = ZonedDateTime.now(ZoneOffset.UTC),
-                includeTimezone = false,
+    fun `DD11 encode-decode round trip preserves coordinates`() {
+        val location =
+            GpsLocation(
+                latitude = 51.5074,
+                longitude = -0.1278,
+                altitude = 0.0,
+                timestamp = ZonedDateTime.of(2024, 3, 20, 15, 45, 0, 0, ZoneOffset.UTC),
             )
-        // Byte 5: Timezone flag (0x00 = omit)
-        assertEquals(0x00.toByte(), packet[5])
+        val encoded = SonyProtocol.encodeLocation(location)
+        val decoded = SonyProtocol.decodeLocation(encoded)
+
+        // Allow for floating-point precision differences
+        assertTrue("Should contain latitude ~51.5074", decoded.contains("51.507"))
+        assertTrue("Should contain longitude ~-0.1278", decoded.contains("-0.127"))
+        assertTrue("Should contain date", decoded.contains("2024-03-20"))
+        assertTrue("Should contain time", decoded.contains("15:45:00"))
+    }
+
+    // ==================== Configuration Parsing Tests ====================
+
+    @Test
+    fun `parseConfigRequiresTimezone returns true when bit 1 is set`() {
+        // byte[4] = 0x02 (bit 1 set) → timezone supported, use 95-byte payload
+        val config = byteArrayOf(0x06, 0x10, 0x00, 0x9C.toByte(), 0x02, 0x00)
+        assertTrue(SonyProtocol.parseConfigRequiresTimezone(config))
     }
 
     @Test
-    fun `parseConfigRequiresTimezone returns true when bit 2 is set`() {
+    fun `parseConfigRequiresTimezone returns true when bit 1 is set with other bits`() {
+        // byte[4] = 0x06 (bits 1 and 2 set) → timezone supported, use 95-byte payload
         val config = byteArrayOf(0x06, 0x10, 0x00, 0x9C.toByte(), 0x06, 0x00)
         assertTrue(SonyProtocol.parseConfigRequiresTimezone(config))
     }
 
     @Test
-    fun `parseConfigRequiresTimezone returns false when bit 2 is not set`() {
-        val config = byteArrayOf(0x06, 0x10, 0x00, 0x9C.toByte(), 0x02, 0x00)
+    fun `parseConfigRequiresTimezone returns false when bit 1 is not set`() {
+        // byte[4] = 0x04 (bit 2 set, but not bit 1) → timezone NOT supported, use 91-byte payload
+        val config = byteArrayOf(0x06, 0x10, 0x00, 0x9C.toByte(), 0x04, 0x00)
+        assertFalse(SonyProtocol.parseConfigRequiresTimezone(config))
+    }
+
+    @Test
+    fun `parseConfigRequiresTimezone returns false when byte 4 is zero`() {
+        // byte[4] = 0x00 (no bits set) → timezone NOT supported, use 91-byte payload
+        val config = byteArrayOf(0x06, 0x10, 0x00, 0x9C.toByte(), 0x00, 0x00)
         assertFalse(SonyProtocol.parseConfigRequiresTimezone(config))
     }
 
@@ -253,6 +577,8 @@ class SonyProtocolTest {
     fun `parseConfigRequiresTimezone returns false for short data`() {
         assertFalse(SonyProtocol.parseConfigRequiresTimezone(byteArrayOf(0x01, 0x02)))
     }
+
+    // ==================== Helper Command Tests ====================
 
     @Test
     fun `createStatusNotifyEnable returns correct bytes`() {
@@ -273,6 +599,13 @@ class SonyProtocolTest {
     }
 
     @Test
+    fun `getPairingInitData returns same as createPairingInit`() {
+        assertArrayEquals(SonyProtocol.createPairingInit(), SonyProtocol.getPairingInitData())
+    }
+
+    // ==================== Geo-tagging Tests ====================
+
+    @Test
     fun `encodeGeoTaggingEnabled returns empty array`() {
         assertEquals(0, SonyProtocol.encodeGeoTaggingEnabled(true).size)
         assertEquals(0, SonyProtocol.encodeGeoTaggingEnabled(false).size)
@@ -282,5 +615,55 @@ class SonyProtocolTest {
     fun `decodeGeoTaggingEnabled returns false`() {
         assertFalse(SonyProtocol.decodeGeoTaggingEnabled(byteArrayOf(0x01)))
         assertFalse(SonyProtocol.decodeGeoTaggingEnabled(byteArrayOf()))
+    }
+
+    // ==================== Byte Order Verification Tests ====================
+
+    @Test
+    fun `verify Big-Endian is used throughout - explicit byte check`() {
+        val dateTime = ZonedDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
+        val location =
+            GpsLocation(
+                latitude = 1.0, // 10,000,000 = 0x00989680
+                longitude = 2.0, // 20,000,000 = 0x01312D00
+                altitude = 0.0,
+                timestamp = dateTime,
+            )
+        val encoded = SonyProtocol.encodeLocation(location)
+
+        // Year 2025 = 0x07E9
+        // If Big-Endian: bytes would be 0x07, 0xE9
+        assertEquals("Year high byte should be 0x07 for Big-Endian", 0x07.toByte(), encoded[19])
+        assertEquals("Year low byte should be 0xE9 for Big-Endian", 0xE9.toByte(), encoded[20])
+
+        // Latitude 10,000,000 = 0x00989680
+        // Big-Endian: 0x00, 0x98, 0x96, 0x80
+        assertEquals(0x00.toByte(), encoded[11])
+        assertEquals(0x98.toByte(), encoded[12])
+        assertEquals(0x96.toByte(), encoded[13])
+        assertEquals(0x80.toByte(), encoded[14])
+
+        // Longitude 20,000,000 = 0x01312D00
+        // Big-Endian: 0x01, 0x31, 0x2D, 0x00
+        assertEquals(0x01.toByte(), encoded[15])
+        assertEquals(0x31.toByte(), encoded[16])
+        assertEquals(0x2D.toByte(), encoded[17])
+        assertEquals(0x00.toByte(), encoded[18])
+    }
+
+    @Test
+    fun `verify CC13 uses Big-Endian - explicit byte check`() {
+        // Year 2025 = 0x07E9
+        // UTC+9 = +9 hours, 0 minutes (split format)
+        val dateTime = ZonedDateTime.of(2025, 1, 1, 12, 0, 0, 0, ZoneOffset.ofHours(9))
+        val encoded = SonyProtocol.encodeDateTime(dateTime)
+
+        // Year (bytes 3-4) - Big-Endian
+        assertEquals("Year high byte", 0x07.toByte(), encoded[3])
+        assertEquals("Year low byte", 0xE9.toByte(), encoded[4])
+
+        // Timezone offset (bytes 11-12) - Split format
+        assertEquals("TZ hours", 9.toByte(), encoded[11])
+        assertEquals("TZ minutes", 0.toByte(), encoded[12])
     }
 }

--- a/docs/sony/DATETIME_GPS_SYNC.md
+++ b/docs/sony/DATETIME_GPS_SYNC.md
@@ -1,0 +1,298 @@
+# Camera Date, Time, and Location Synchronization Protocol
+
+This document details the reverse-engineered protocol used to synchronize date, time, and location information with the camera. The synchronization is performed entirely over **Bluetooth Low Energy (BLE)**; Wi-Fi is **not** used for this process.
+
+## 1. Camera Discovery & Identification
+
+The app identifies the camera through BLE advertising packets containing specific Manufacturer Specific Data.
+
+*   **Manufacturer ID**: `0x012D` (Sony) - *Note: Little-endian representation of 301*
+*   **Scan Mode**: Low Power (continuous background scanning)
+*   **Advertising Packet Structure**:
+    *   **Company ID**: `0x2D 0x01` (Sony)
+    *   **Device Type**: `0x03 0x00` (Sony Camera)
+    *   **Reserved**: 2 bytes
+    *   **Model Code**: 2 bytes (UTF-8 string, e.g., "U0", "U1")
+    *   **Flags (TLV)**:
+        *   **Tag 0x21 (33)**: Power/Wi-Fi status (Bit 7: WirelessPowerOnEnabled, Bit 6: CameraOn, Bit 5: WifiHandoverSupported, Bit 4: WifiHandoverEnabled)
+        *   **Tag 0x22 (34)**: Pairing/Location status (Bit 7: PairingSupported, Bit 6: PairingEnabled, Bit 5: LocationSupported, Bit 4: LocationEnabled)
+
+## 2. Services & Characteristics
+
+Two primary GATT services are used for synchronization:
+
+### A. Camera Control Service (Date/Time)
+**UUID**: `8000CC00-CC00-FFFF-FFFF-FFFFFFFFFFFF`
+
+| Characteristic UUID | Access | Description |
+| :--- | :--- | :--- |
+| `0000CC13-...` | Write | **Time Area Setting**: Sets the current time and timezone. |
+| `0000CC12-...` | Write | **Date Format Setting**: Sets the date display format (YMD/DMY/etc). |
+| `0000CC0E-...` | Notify | **Notification**: Confirmation of setting success/failure. |
+| `0000CC09-...` | Read | **Completion Status**: Checks if time setting is done. |
+| `0000CC03-...` | Notify | **Push Transfer**: Notifies when camera media is ready for transfer. |
+| `0000CC0F-...` | Notify | **Media Status**: Updates on SD card / recording capacity. |
+| `0000CC10-...` | Notify | **Battery Status**: Updates on camera battery levels. |
+| `0000CCA6-...` | Notify | **Lens Info**: Updates on attached lens status. |
+
+### B. Location Service (GPS)
+**UUID**: `8000DD00-DD00-FFFF-FFFF-FFFFFFFFFFFF`
+
+| Characteristic UUID | Access | Description |
+| :--- | :--- | :--- |
+| `0000DD11-...` | Write | **Location Data**: The actual GPS and timestamp payload. |
+| `0000DD30-...` | Write | **Lock Control**: Locks/Unlocks the location transfer session (`1`=Lock, `0`=Unlock). |
+| `0000DD31-...` | Write | **Transfer Enable**: Enables/Disables transfer (`1`=Enable, `0`=Disable). |
+| `0000DD01-...` | Notify | **Notification**: Updates on transfer status. |
+| `0000DD21-...` | Read | **Capability Info**: Reads camera capabilities. |
+
+---
+
+## 3. Date & Time Synchronization Flow
+
+This process runs during initial setup or when the app detects a time difference.
+
+### Step 1: Subscribe to Notifications
+*   Enable notifications on `0000CC0E` (Write CCCD).
+
+### Step 2: Set Date Format (Optional/Initial Setup)
+*   **Characteristic**: `0000CC12`
+*   **Payload** (4 bytes): `{ 0x03, 0x00, 0x00, FORMAT_VALUE }`
+    *   `FORMAT_VALUE`:
+        *   `1`: YMD (Year/Month/Day)
+        *   `2`: DMY
+        *   `3`: MDY
+        *   `4`: MDY_E
+*   **Wait**: Expect notification on `0000CC0E` with success status.
+
+### Step 3: Set Time & Timezone
+*   **Characteristic**: `0000CC13`
+*   **Payload** (13 bytes): `BluetoothGattUtil.serializeTimeAreaData()`
+
+| Byte Offset | Value | Description |
+| :--- | :--- | :--- |
+| 0-2 | `0x0C 0x00 0x00` | Header (Fixed) |
+| 3-4 | `uint16` | Year (Big-Endian) |
+| 5 | `uint8` | Month (1-12) |
+| 6 | `uint8` | Day (1-31) |
+| 7 | `uint8` | Hour (0-23) |
+| 8 | `uint8` | Minute (0-59) |
+| 9 | `uint8` | Second (0-59) |
+| 10 | `0x00` / `0x01` | DST Flag (0=Standard, 1=DST) |
+| 11 | `int8` | Timezone Offset Hours (Signed) |
+| 12 | `uint8` | Timezone Offset Minutes |
+
+*   **Wait**: Expect notification on `0000CC0E` confirming success.
+
+---
+
+## 4. Location Synchronization Flow
+
+Location sync requires a "locking" handshake before data can be streamed.
+
+### Phase 1: Locking & Setup
+0.  **Subscribe to DD01 Notifications**: Write CCCD descriptor to enable notifications on `0000DD01`. This **MUST** be done FIRST before any other operations. The camera sends notifications on DD01 when location transfer is disabled.
+1.  **Lock Session**: Write `{ 0x01 }` to `0000DD30`.
+2.  **Enable Transfer**: Write `{ 0x01 }` to `0000DD31`.
+3.  **Read Capabilities** (in this order per Sony app):
+    *   Read `0000DD32` (Time Correction).
+    *   Read `0000DD33` (Area Adjustment).
+    *   **CRITICAL**: Read `0000DD21` (Camera Info). This determines if the camera supports timezone data.
+        *   **Check**: Examine the 5th byte (Index 4) of the response.
+        *   **Mask**: `0x02` (Bit 1).
+        *   **Logic**: If `(Byte4 & 0x02) == 0x02`, the camera **SUPPORTS** timezone data (use 95-byte payload). Otherwise, it does **NOT** (use 91-byte payload).
+4.  **Wait for Ready**: The app waits for the `onTransferReady` internal state.
+
+### Phase 2: Sending Location Updates
+When a valid GPS location (< 10 seconds old) is received, construct the payload based on the capability check in Phase 1.
+
+#### Option A: Camera Supports Timezone (95 Bytes)
+Used if `(0000DD21_Value[4] & 0x02) == 0x02`.
+
+| Byte Offset | Value | Description |
+| :--- | :--- | :--- |
+| 0-1 | `0x00 0x5D` | Total Length (93 + 2 header bytes) |
+| 2-4 | `0x08 0x02 0xFC` | Protocol Header |
+| 5 | `0x03` | **Flag**: Timezone/DST present |
+| 6-7 | `0x00` | Padding |
+| 8-10 | `0x10` | Fixed Padding (16) |
+| 11-14 | `int32` | **Latitude** * 10,000,000 (Big-Endian) |
+| 15-18 | `int32` | **Longitude** * 10,000,000 (Big-Endian) |
+| 19-20 | `uint16` | Year (Big-Endian) |
+| 21 | `uint8` | Month |
+| 22 | `uint8` | Day |
+| 23 | `uint8` | Hour |
+| 24 | `uint8` | Minute |
+| 25 | `uint8` | Second |
+| ... | ... | Padding/Reserved |
+| 91-92 | `int16` | **Timezone Offset** (Minutes, Big-Endian) |
+| 93-94 | `int16` | **DST Savings** (Minutes, Big-Endian) |
+
+#### Option B: No Timezone Support (91 Bytes)
+Used if `(0000DD21_Value[4] & 0x02) != 0x02`.
+
+| Byte Offset | Value | Description |
+| :--- | :--- | :--- |
+| 0-1 | `0x00 0x59` | Total Length (89 + 2 header bytes) |
+| 2-4 | `0x08 0x02 0xFC` | Protocol Header |
+| 5 | `0x00` | **Flag**: No Timezone |
+| 6-7 | `0x00` | Padding |
+| 8-10 | `0x10` | Fixed Padding (16) |
+| 11-14 | `int32` | Latitude * 10,000,000 (Big-Endian) |
+| 15-18 | `int32` | Longitude * 10,000,000 (Big-Endian) |
+| 19-25 | ... | Date/Time (Same as above) |
+| 26-90 | ... | Padding/Reserved |
+
+### Phase 3: Unlocking/Cleanup
+To stop syncing:
+1.  **Disable Transfer**: Write `{ 0x00 }` to `0000DD31`.
+2.  **Unlock Session**: Write `{ 0x00 }` to `0000DD30`.
+
+---
+
+## 5. Error Handling & Edge Cases
+
+### Timeouts
+*   **Command Timeout**: All BLE write operations have a **30-second timeout**. If no success notification is received within this window, the operation is aborted.
+*   **Failure Action**: The state machine transitions to `IdleState` and invokes the failure callback.
+
+### Retries
+*   **Time Sync**: No automatic retries. Fails immediately on error or timeout.
+*   **Location Sync**:
+    *   Write failures to `0000DD11` are retried up to **3 times**.
+    *   If the camera actively disables location (notification on `0000DD01`), the app transitions to `TransferringLocationInfoUnlockingState` with an `OffByCamera` error.
+
+### Connection Loss
+*   **Disconnect**: If the BLE connection drops (`onGattDisconnected`), all active commands are aborted. The app must re-scan and re-connect to resume.
+
+### Implementation Notes for Clean-Room Reimplementation
+1.  **Big-Endian (Network Byte Order)**: All multi-byte integers (Year, Latitude, Longitude) are encoded as **Big-Endian**.
+    *   *Correction from previous version*: The Android `ByteBuffer` default is Big-Endian, and the decompiled code does not change this order.
+2.  **Time Reference Differs Between Characteristics**:
+    *   **Time Sync (CC13)**: Uses **LOCAL time** components (from `ZonedDateTime`) alongside timezone offset.
+    *   **Location Sync (DD11)**: Uses **UTC time** (from `Calendar.getInstance(TimeZone.getTimeZone("UTC"))`).
+3.  **Timezone Formats Differ**:
+    *   **Time Sync (CC13)**: Uses a custom split format (Byte 11 = Signed Hour, Byte 12 = Minute).
+    *   **Location Sync (DD11)**: Uses a standard `int16` (Big-Endian) for total minutes.
+4.  **GPS Precision**: Multiply Latitude/Longitude by `1E7` and cast to integer.
+5.  **State Machine**: Implement a robust state machine to handle the Lock -> Enable -> Write -> Unlock sequence. Do not attempt to write location data without first locking and enabling.
+6.  **Freshness**: Only send location data if it is fresh (< 10s old). Stale data should be discarded.
+7.  **Keep-Alive Mechanism**: The camera has an internal timeout for location data. If it doesn't receive location updates for an extended period (observed: ~2 minutes), it will show a 🚫 icon on the location link indicator, even if the BLE session is still active. To prevent this:
+    *   Implement a keep-alive timer that runs every **30 seconds**.
+    *   If no fresh GPS location has been received and sent within the interval, re-send the **last known location** with a **fresh timestamp**.
+    *   This keeps the camera's location indicator active during periods when the phone's GPS is not providing frequent updates (e.g., indoors, stationary).
+    *   The keep-alive uses the same DD11 characteristic and packet format as normal location updates.
+
+---
+
+## 6. Reference Implementation (Pseudo-Code)
+
+Below are Python-like snippets demonstrating the exact packet creation logic, ensuring zero ambiguity regarding byte order and structure.
+
+### Time Sync Packet (`0000CC13`)
+
+```python
+import struct
+
+def create_time_sync_packet(year, month, day, hour, minute, second, 
+                            tz_offset_hours, tz_offset_minutes, is_dst):
+    """
+    Creates the 13-byte payload for characteristic 0000CC13.
+    """
+    packet = bytearray(13)
+    
+    # Header
+    packet[0] = 0x0C
+    packet[1] = 0x00
+    packet[2] = 0x00
+    
+    # Year: Big-Endian uint16
+    struct.pack_into('>H', packet, 3, year)
+    
+    # Date/Time components
+    packet[5] = month
+    packet[6] = day
+    packet[7] = hour
+    packet[8] = minute
+    packet[9] = second
+    
+    # DST Flag (1 = DST, 0 = Standard)
+    packet[10] = 1 if is_dst else 0
+    
+    # Timezone Offset (Custom Split Format)
+    # Byte 11: Signed hours (int8)
+    # Byte 12: Minutes (uint8)
+    struct.pack_into('b', packet, 11, tz_offset_hours)
+    packet[12] = tz_offset_minutes
+    
+    return packet
+```
+
+### Location Sync Packet (`0000DD11`)
+
+```python
+import struct
+
+def create_location_sync_packet(lat_deg, lon_deg, 
+                                utc_year, utc_month, utc_day, utc_hour, utc_minute, utc_second,
+                                tz_total_minutes=0, dst_savings_minutes=0,
+                                camera_supports_timezone=False):
+    """
+    Creates the 91 or 95-byte payload for characteristic 0000DD11.
+    
+    IMPORTANT: Time components must be in UTC (not local time).
+    Use Calendar.getInstance(TimeZone.getTimeZone("UTC")) to extract components.
+    The timezone offset tells the camera how to convert to local time.
+    """
+    
+    # Determine length based on camera capability
+    if camera_supports_timezone:
+        length = 95
+        payload_len_field = 93 # 0x5D
+        flag_byte = 0x03
+    else:
+        length = 91
+        payload_len_field = 89 # 0x59
+        flag_byte = 0x00
+        
+    packet = bytearray(length)
+    
+    # Header: Total Length (uint16 Big-Endian)
+    struct.pack_into('>H', packet, 0, payload_len_field)
+    
+    # Protocol Header
+    packet[2] = 0x08
+    packet[3] = 0x02
+    packet[4] = 0xFC
+    
+    # Flags / Padding
+    packet[5] = flag_byte
+    # Bytes 6-7 are 0x00, bytes 8-10 are 0x10 (Fixed Padding)
+    packet[8] = 0x10
+    packet[9] = 0x10
+    packet[10] = 0x10
+    
+    # Latitude / Longitude: int32 Big-Endian (degrees * 1E7)
+    lat_int = int(lat_deg * 10000000)
+    lon_int = int(lon_deg * 10000000)
+    
+    struct.pack_into('>i', packet, 11, lat_int)
+    struct.pack_into('>i', packet, 15, lon_int)
+    
+    # Date / Time (UTC!)
+    struct.pack_into('>H', packet, 19, utc_year) # Year Big-Endian
+    packet[21] = utc_month
+    packet[22] = utc_day
+    packet[23] = utc_hour
+    packet[24] = utc_minute
+    packet[25] = utc_second
+    
+    # Timezone Data (Only if supported)
+    if camera_supports_timezone:
+        # Timezone Offset: int16 Big-Endian (Total minutes)
+        struct.pack_into('>h', packet, 91, tz_total_minutes)
+        # DST Savings: int16 Big-Endian (Total minutes)
+        struct.pack_into('>h', packet, 93, dst_savings_minutes)
+        
+    return packet
+```


### PR DESCRIPTION
- Implemented comprehensive Sony BLE synchronization protocol based on reverse-engineered documentation, covering both `CC13` (Date/Time) and `DD11` (Location) characteristics.
- Added support for Sony's newer location sync handshake, including session locking (`DD30`), transfer enablement (`DD31`), and capability discovery (`DD21`, `DD32`, `DD33`).
- Updated `GpsLocation` to include freshness checking, ensuring location data is only synchronized if it is less than 10 seconds old per protocol specifications.
- Refactored `KableCameraConnection` to handle Sony-specific requirements, such as requesting a 158-byte MTU, implementing a 30-second write timeout, and adding retry logic for location writes.
- Improved protocol encoding to utilize Big-Endian byte order consistently for multi-byte values and handle timezone/DST offsets correctly.
- Enhanced `MultiDeviceSyncCoordinator` to skip redundant initial date/time syncs for cameras using unified packets.
- Introduced `bleProtocolVersion` parsing from manufacturer data to differentiate between legacy and modern Sony synchronization flows.
- Added exhaustive unit tests for GPS location freshness and Sony protocol encoding/decoding accuracy.

These changes ensure robust and accurate synchronization with a wider range of Sony cameras, particularly those with newer firmware requiring specific BLE handshake sequences.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core BLE connection/sync logic for Sony devices (MTU negotiation, multi-step GATT handshake, timeouts/retries, notification observation), which can affect connection stability and location/time sync behavior across devices.
> 
> **Overview**
> Improves Sony BLE sync support by **switching date/time sync to the dedicated CC13 characteristic** and adding protocol-aware location sync behavior (DD11) including **DD30/DD31 unlock/enable**, capability reads (DD21/DD32/DD33) to decide whether to include timezone bytes, and safer BLE writes (30s timeouts, `WithResponse`, and retry-on-failure for location).
> 
> Adds Sony-specific connection tweaks (MTU 158 request), persists Sony BLE protocol version from advertisement manufacturer data on the `Camera` model, and updates multi-device syncing to **discard stale GPS points (<10s freshness rule)** while adding a 30s **keep-alive resend** of the last location with a fresh timestamp to prevent Sony location timeout.
> 
> Extends the protocol interface (`encodeLocation(..., includeTimezone)`) and updates implementations/tests; adds detailed Sony protocol docs and expands unit test coverage for Sony GATT/protocol encoding and `GpsLocation` freshness helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f002b811bd87f03317c3d54c1bcbfbd036507174. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->