### PR TITLE
Refactor WorkManager initialization and enhance firmware update scheduling

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -16,4 +16,7 @@
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
+  <component name="VcsProjectSettings">
+    <option name="detectVcsMappingsAutomatically" value="false" />
+  </component>
 </project>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -152,6 +152,19 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+
+        <!-- Disable default WorkManagerInitializer to allow Configuration.Provider initialization -->
+        <!-- WorkManagerInitializer is registered via androidx.startup.InitializationProvider -->
+        <!-- We need to remove its meta-data entry from the InitializationProvider -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                tools:node="remove" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/data/repository/DataStorePairedDevicesRepository.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/data/repository/DataStorePairedDevicesRepository.kt
@@ -147,7 +147,11 @@ class DataStorePairedDevicesRepository(private val dataStore: DataStore<PairedDe
         }
     }
 
-    override suspend fun setFirmwareUpdateInfo(macAddress: String, latestVersion: String?) {
+    override suspend fun setFirmwareUpdateInfo(
+        macAddress: String,
+        latestVersion: String?,
+        lastCheckedAt: Long,
+    ) {
         dataStore.updateData { currentData ->
             val deviceIndex = currentData.devicesList.indexOfFirst { it.macAddress == macAddress }
 
@@ -157,6 +161,7 @@ class DataStorePairedDevicesRepository(private val dataStore: DataStore<PairedDe
                 currentData.devicesList[deviceIndex]
                     .toBuilder()
                     .apply {
+                        setLastFirmwareCheckedAt(lastCheckedAt)
                         if (latestVersion != null) {
                             setLatestFirmwareVersion(latestVersion)
                             // Clear notification shown flag when new update is found
@@ -200,6 +205,7 @@ private fun PairedDeviceProto.toDomain(): PairedDevice =
         firmwareVersion = if (hasFirmwareVersion()) firmwareVersion else null,
         latestFirmwareVersion = if (hasLatestFirmwareVersion()) latestFirmwareVersion else null,
         firmwareUpdateNotificationShown = firmwareUpdateNotificationShown,
+        lastFirmwareCheckedAt = if (hasLastFirmwareCheckedAt()) lastFirmwareCheckedAt else null,
     )
 
 /** Serializer for [PairedDevicesProto] used by DataStore. */

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/devices/DeviceCard.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/devices/DeviceCard.kt
@@ -238,10 +238,7 @@ private fun DeviceDetailRow(label: String, value: String) {
 
 @Composable
 private fun DeviceDetailRowWithBadge(label: String, value: String, latestVersion: String?) {
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
+    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
         Text(
             text = label,
             style = MaterialTheme.typography.labelMedium,
@@ -256,6 +253,7 @@ private fun DeviceDetailRowWithBadge(label: String, value: String, latestVersion
                 text = value,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.alignByBaseline(),
             )
             if (latestVersion != null) {
                 Badge(

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/devicesync/MultiDeviceSyncService.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/devicesync/MultiDeviceSyncService.kt
@@ -24,6 +24,7 @@ import dev.sebastiano.camerasync.domain.model.DeviceConnectionState
 import dev.sebastiano.camerasync.domain.model.PairedDevice
 import dev.sebastiano.camerasync.domain.repository.PairedDevicesRepository
 import dev.sebastiano.camerasync.domain.repository.SyncStatusRepository
+import dev.sebastiano.camerasync.firmware.FirmwareUpdateScheduler
 import dev.zacsweers.metro.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineName
@@ -132,6 +133,7 @@ class MultiDeviceSyncService(
                 startForegroundService()
                 startDeviceMonitoring()
                 launch { refreshConnections() }
+                FirmwareUpdateScheduler.triggerOneTimeCheck(this)
             }
             ACTION_DEVICE_FOUND -> {
                 Log.info(tag = TAG) {

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/domain/model/PairedDevice.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/domain/model/PairedDevice.kt
@@ -20,6 +20,8 @@ import dev.sebastiano.camerasync.domain.vendor.CameraVendor
  *   "2.02"), or null if no update is available or unknown.
  * @param firmwareUpdateNotificationShown Whether the user has already been notified about the
  *   firmware update. This prevents showing the notification multiple times.
+ * @param lastFirmwareCheckedAt The timestamp of the last time we checked for firmware updates
+ *   (millis since epoch), or null if never checked.
  */
 data class PairedDevice(
     val macAddress: String,
@@ -30,6 +32,7 @@ data class PairedDevice(
     val firmwareVersion: String? = null,
     val latestFirmwareVersion: String? = null,
     val firmwareUpdateNotificationShown: Boolean = false,
+    val lastFirmwareCheckedAt: Long? = null,
 )
 
 /** Represents the current connection state of a paired device. */

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/domain/repository/PairedDevicesRepository.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/domain/repository/PairedDevicesRepository.kt
@@ -94,8 +94,13 @@ interface PairedDevicesRepository {
      * @param latestVersion The latest firmware version available, or null to clear (no update
      *   available). When an update is found, this clears the notification shown flag so the user
      *   can be notified.
+     * @param lastCheckedAt The timestamp when the check was performed (millis since epoch).
      */
-    suspend fun setFirmwareUpdateInfo(macAddress: String, latestVersion: String?)
+    suspend fun setFirmwareUpdateInfo(
+        macAddress: String,
+        latestVersion: String?,
+        lastCheckedAt: Long,
+    )
 
     /**
      * Marks that the firmware update notification has been shown to the user.

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/firmware/FirmwareUpdateCheckWorker.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/firmware/FirmwareUpdateCheckWorker.kt
@@ -50,6 +50,7 @@ class FirmwareUpdateCheckWorker(
                 checkedCount++
 
                 val result = checker.checkForUpdate(device, device.firmwareVersion)
+                val now = System.currentTimeMillis()
 
                 when (result) {
                     is FirmwareUpdateCheckResult.UpdateAvailable -> {
@@ -60,6 +61,7 @@ class FirmwareUpdateCheckWorker(
                         pairedDevicesRepository.setFirmwareUpdateInfo(
                             device.macAddress,
                             result.latestVersion,
+                            lastCheckedAt = now,
                         )
                         updateFoundCount++
                     }
@@ -68,7 +70,11 @@ class FirmwareUpdateCheckWorker(
                             "No firmware update available for ${device.macAddress}"
                         }
                         // Clear update info if it was previously set
-                        pairedDevicesRepository.setFirmwareUpdateInfo(device.macAddress, null)
+                        pairedDevicesRepository.setFirmwareUpdateInfo(
+                            device.macAddress,
+                            null,
+                            lastCheckedAt = now,
+                        )
                     }
                     is FirmwareUpdateCheckResult.CheckFailed -> {
                         Log.warn(tag = TAG) {

--- a/app/src/main/kotlin/dev/sebastiano/camerasync/firmware/FirmwareUpdateScheduler.kt
+++ b/app/src/main/kotlin/dev/sebastiano/camerasync/firmware/FirmwareUpdateScheduler.kt
@@ -23,20 +23,30 @@ object FirmwareUpdateScheduler {
      * Schedules a periodic firmware update check that runs once per day.
      *
      * This should be called when the app starts (e.g., in MainActivity.onCreate()).
+     *
+     * @throws IllegalStateException if WorkManager is not initialized (shouldn't happen if
+     *   Application implements Configuration.Provider)
      */
     fun scheduleDailyCheck(context: Context) {
-        val constraints =
-            Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build()
+        try {
+            val constraints =
+                Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build()
 
-        val workRequest =
-            PeriodicWorkRequest.Builder(FirmwareUpdateCheckWorker::class.java, 1, TimeUnit.DAYS)
-                .setConstraints(constraints)
-                .build()
+            val workRequest =
+                PeriodicWorkRequest.Builder(FirmwareUpdateCheckWorker::class.java, 1, TimeUnit.DAYS)
+                    .setConstraints(constraints)
+                    .build()
 
-        WorkManager.getInstance(context)
-            .enqueueUniquePeriodicWork(WORK_NAME, ExistingPeriodicWorkPolicy.KEEP, workRequest)
+            WorkManager.getInstance(context)
+                .enqueueUniquePeriodicWork(WORK_NAME, ExistingPeriodicWorkPolicy.KEEP, workRequest)
 
-        Log.info(tag = TAG) { "Scheduled daily firmware update check" }
+            Log.info(tag = TAG) { "Scheduled daily firmware update check" }
+        } catch (e: IllegalStateException) {
+            Log.error(tag = TAG, throwable = e) {
+                "Failed to schedule firmware update check: WorkManager not initialized"
+            }
+            throw e // Re-throw to allow caller to handle
+        }
     }
 
     /**
@@ -45,7 +55,14 @@ object FirmwareUpdateScheduler {
      * This can be called if firmware update checking should be disabled.
      */
     fun cancelCheck(context: Context) {
-        WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
-        Log.info(tag = TAG) { "Cancelled firmware update check" }
+        try {
+            WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+            Log.info(tag = TAG) { "Cancelled firmware update check" }
+        } catch (e: IllegalStateException) {
+            Log.warn(tag = TAG, throwable = e) {
+                "Failed to cancel firmware update check: WorkManager not initialized"
+            }
+            // Don't re-throw for cancel operations - it's okay if WorkManager isn't initialized
+        }
     }
 }

--- a/app/src/main/proto/PairedDevices.proto
+++ b/app/src/main/proto/PairedDevices.proto
@@ -28,6 +28,9 @@ message PairedDeviceProto {
 
   // Whether the user has already been notified about the firmware update
   bool firmware_update_notification_shown = 8;
+
+  // The timestamp of the last time we checked for firmware updates (millis since epoch)
+  optional int64 last_firmware_checked_at = 9;
 }
 
 // Collection of all paired devices
@@ -39,4 +42,3 @@ message PairedDevicesProto {
   // If false, the service won't start automatically.
   optional bool sync_enabled = 2;
 }
-

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/fakes/FakePairedDevicesRepository.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/fakes/FakePairedDevicesRepository.kt
@@ -142,12 +142,17 @@ class FakePairedDevicesRepository : PairedDevicesRepository {
         }
     }
 
-    override suspend fun setFirmwareUpdateInfo(macAddress: String, latestVersion: String?) {
+    override suspend fun setFirmwareUpdateInfo(
+        macAddress: String,
+        latestVersion: String?,
+        lastCheckedAt: Long,
+    ) {
         _devices.update { devices ->
             devices.map { device ->
                 if (device.macAddress == macAddress) {
                     device.copy(
                         latestFirmwareVersion = latestVersion,
+                        lastFirmwareCheckedAt = lastCheckedAt,
                         firmwareUpdateNotificationShown =
                             false, // Clear flag when update info changes
                     )

--- a/app/src/test/kotlin/dev/sebastiano/camerasync/firmware/FirmwareUpdateSchedulerTest.kt
+++ b/app/src/test/kotlin/dev/sebastiano/camerasync/firmware/FirmwareUpdateSchedulerTest.kt
@@ -1,0 +1,105 @@
+package dev.sebastiano.camerasync.firmware
+
+import android.content.Context
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.PeriodicWorkRequest
+import androidx.work.WorkManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class FirmwareUpdateSchedulerTest {
+
+    private val context = mockk<Context>(relaxed = true)
+    private val workManager = mockk<WorkManager>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        mockkObject(WorkManager.Companion)
+        every { WorkManager.getInstance(any()) } returns workManager
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(WorkManager.Companion)
+    }
+
+    @Test
+    fun `triggerOneTimeCheck schedules work with network constraint`() {
+        val workRequestSlot = slot<OneTimeWorkRequest>()
+
+        FirmwareUpdateScheduler.triggerOneTimeCheck(context)
+
+        verify {
+            workManager.enqueueUniqueWork(
+                "firmware_update_check_one_time",
+                ExistingWorkPolicy.REPLACE,
+                capture(workRequestSlot),
+            )
+        }
+
+        val constraints = workRequestSlot.captured.workSpec.constraints
+        assertEquals(NetworkType.CONNECTED, constraints.requiredNetworkType)
+    }
+
+    @Test
+    fun `scheduleDailyCheck schedules periodic work with network constraint`() {
+        val workRequestSlot = slot<PeriodicWorkRequest>()
+
+        FirmwareUpdateScheduler.scheduleDailyCheck(context)
+
+        verify {
+            workManager.enqueueUniquePeriodicWork(
+                "firmware_update_check",
+                ExistingPeriodicWorkPolicy.KEEP,
+                capture(workRequestSlot),
+            )
+        }
+
+        val constraints = workRequestSlot.captured.workSpec.constraints
+        assertEquals(NetworkType.CONNECTED, constraints.requiredNetworkType)
+    }
+
+    @Test
+    fun `cancelCheck cancels both periodic and one-time work`() {
+        FirmwareUpdateScheduler.cancelCheck(context)
+
+        verify {
+            workManager.cancelUniqueWork("firmware_update_check")
+            workManager.cancelUniqueWork("firmware_update_check_one_time")
+        }
+    }
+
+    @Test
+    fun `triggerOneTimeCheck handles WorkManager initialization failure`() {
+        every { WorkManager.getInstance(any()) } throws IllegalStateException("Not initialized")
+
+        // Should not crash
+        FirmwareUpdateScheduler.triggerOneTimeCheck(context)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `scheduleDailyCheck rethrows WorkManager initialization failure`() {
+        every { WorkManager.getInstance(any()) } throws IllegalStateException("Not initialized")
+
+        FirmwareUpdateScheduler.scheduleDailyCheck(context)
+    }
+
+    @Test
+    fun `cancelCheck handles WorkManager initialization failure`() {
+        every { WorkManager.getInstance(any()) } throws IllegalStateException("Not initialized")
+
+        // Should not crash
+        FirmwareUpdateScheduler.cancelCheck(context)
+    }
+}


### PR DESCRIPTION

- Updated `AndroidManifest.xml` to disable the default `WorkManagerInitializer`, allowing for manual initialization with a custom factory.
- Simplified `WorkManager` initialization logic in `CameraSyncApp` by removing redundant try-catch blocks, as manual initialization is now explicitly configured.
- Ensured `FirmwareUpdateScheduler` consistently schedules daily checks following the manual WorkManager setup.

These changes ensure a more predictable initialization flow for WorkManager and improve the reliability of the firmware update background tasks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect app startup and WorkManager scheduling/execution paths, plus a persisted schema update; regressions could break background firmware checks or cause initialization issues on some devices.
> 
> **Overview**
> **WorkManager initialization is refactored** to rely on `Configuration.Provider` (custom `WorkerFactory` via `CameraSyncApp.workManagerConfiguration`) and the manifest now disables the default `androidx.work.WorkManagerInitializer` to avoid double-init conflicts.
> 
> **Startup work is shifted off the main thread** by moving app-graph/widget init and daily firmware scheduling into a background coroutine, with error handling that prevents startup crashes.
> 
> **Firmware update checks are enhanced** by persisting `lastFirmwareCheckedAt` (proto + domain + repositories), recording it on successful/"no update" checks, and proactively triggering a one-time check on device connect (stale/missing data) and on manual refresh; `FirmwareUpdateScheduler` now supports one-time work, safer cancelation, and has dedicated unit tests. Sony firmware checking also migrates JSON handling to `kotlinx.serialization`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1c5cd517ea1802419981c5aa31e221ecbee4424. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->